### PR TITLE
GFI Improvements

### DIFF
--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -5,7 +5,6 @@ import numpy as np
 import xarray as xr
 from pyproj import Transformer
 
-from xpublish_wms.grid import GridType
 
 logger = logging.getLogger("uvicorn")
 

--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -80,29 +80,17 @@ to_lnglat = Transformer.from_crs(3857, 4326, always_xy=True)
 to_mercator = Transformer.from_crs(4326, 3857, always_xy=True)
 
 
-def ds_bbox(ds: xr.Dataset) -> Tuple[float, float, float, float]:
+def da_bbox(da: xr.DataArray) -> Tuple[float, float, float, float]:
     """
-    Return the bounding box of the dataset
+    Return the bounding box of the dataarray
     :param ds:
     :return:
     """
-    grid_type = GridType.from_ds(ds)
-
-    if grid_type == GridType.REGULAR:
-        bbox = [
-            ds.cf.coords["longitude"].min().values.item(),
-            ds.cf.coords["latitude"].min().values.item(),
-            ds.cf.coords["longitude"].max().values.item(),
-            ds.cf.coords["latitude"].max().values.item(),
-        ]
-    elif grid_type == GridType.SGRID:
-        topology = ds.cf["grid_topology"]
-        lng_coord, lat_coord = topology.attrs["face_coordinates"].split(" ")
-        bbox = [
-            ds[lng_coord].min().values.item(),
-            ds[lat_coord].min().values.item(),
-            ds[lng_coord].max().values.item(),
-            ds[lat_coord].max().values.item(),
-        ]
+    bbox = [
+        da.cf.coords["longitude"].min().values.item(),
+        da.cf.coords["latitude"].min().values.item(),
+        da.cf.coords["longitude"].max().values.item(),
+        da.cf.coords["latitude"].max().values.item(),
+    ]
 
     return bbox

--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -5,7 +5,6 @@ import numpy as np
 import xarray as xr
 from pyproj import Transformer
 
-
 logger = logging.getLogger("uvicorn")
 
 

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -36,7 +36,7 @@ async def wms_handler(
     elif method == "getfeatureinfo" or method == "gettimeseries":
         return get_feature_info(dataset, query_params)
     elif method == "getverticalprofile":
-        query_params['elevation'] = 'all'
+        query_params["elevation"] = "all"
         return get_feature_info(dataset, query_params)
     elif method == "getmetadata":
         return get_metadata(dataset, cache, query_params)

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -35,6 +35,9 @@ async def wms_handler(
         return getmap_service.get_map(dataset, query_params)
     elif method == "getfeatureinfo" or method == "gettimeseries":
         return get_feature_info(dataset, query_params)
+    elif method == "getverticalprofile":
+        query_params['elevation'] = 'all'
+        return get_feature_info(dataset, query_params)
     elif method == "getmetadata":
         return get_metadata(dataset, cache, query_params)
     elif method == "getlegendgraphic":

--- a/xpublish_wms/wms/get_capabilities.py
+++ b/xpublish_wms/wms/get_capabilities.py
@@ -5,7 +5,7 @@ import cf_xarray  # noqa
 import xarray as xr
 from fastapi import HTTPException, Request, Response
 
-from xpublish_wms.utils import ds_bbox, format_timestamp
+from xpublish_wms.utils import da_bbox, format_timestamp
 
 # WMS Styles declaration
 # TODO: Add others beyond just simple raster
@@ -139,29 +139,31 @@ def get_capabilities(ds: xr.Dataset, request: Request, query_params: dict) -> Re
     create_text_element(layer_tag, crs_tag, "EPSG:3857")
     create_text_element(layer_tag, crs_tag, "CRS:84")
 
-    bbox = ds_bbox(ds)
-    bounds = {
-        crs_tag: "EPSG:4326",
-        "minx": f"{bbox[0]}",
-        "miny": f"{bbox[1]}",
-        "maxx": f"{bbox[2]}",
-        "maxy": f"{bbox[3]}",
-    }
-
-    if version == "1.1.1":
-        ll_bounds = {
-            "minx": f"{bbox[0]}",
-            "miny": f"{bbox[1]}",
-            "maxx": f"{bbox[2]}",
-            "maxy": f"{bbox[3]}",
-        }
-
     for var in ds.data_vars:
         da = ds[var]
 
         # If there are not spatial coords, we can't view it with this router, sorry
         if "longitude" not in da.cf.coords:
             continue
+
+        # TODO: Cache this based on variable names fetched. for now we assume every dataarray
+        # can have a different bbox
+        bbox = da_bbox(da)
+        bounds = {
+            crs_tag: "EPSG:4326",
+            "minx": f"{bbox[0]}",
+            "miny": f"{bbox[1]}",
+            "maxx": f"{bbox[2]}",
+            "maxy": f"{bbox[3]}",
+        }
+
+        if version == "1.1.1":
+            ll_bounds = {
+                "minx": f"{bbox[0]}",
+                "miny": f"{bbox[1]}",
+                "maxx": f"{bbox[2]}",
+                "maxy": f"{bbox[3]}",
+            }
 
         attrs = da.cf.attrs
         layer = ET.SubElement(layer_tag, "Layer", attrib={"queryable": "1"})
@@ -195,8 +197,8 @@ def get_capabilities(ds: xr.Dataset, request: Request, query_params: dict) -> Re
 
         ET.SubElement(layer, "BoundingBox", attrib=bounds)
 
-        if "T" in da.cf.axes:
-            times = format_timestamp(da.cf["T"])
+        if "time" in da.cf.coords:
+            times = format_timestamp(da.cf["time"])
 
             time_dimension_element = ET.SubElement(
                 layer,
@@ -209,6 +211,22 @@ def get_capabilities(ds: xr.Dataset, request: Request, query_params: dict) -> Re
             )
             # TODO: Add ISO duration specifier
             time_dimension_element.text = f"{','.join(times)}"
+
+        if 'vertical' in da.cf.coords:
+            default_elevation = float(da.cf['vertical'].cf.sel(vertical=0, method='nearest').values)
+            elevations = [f'{e}' for e in da.cf['vertical'].values.round(5)]
+            elevation_units = da.cf['vertical'].attrs.get('units', 'sigma')
+            elevation_dimension_element = ET.SubElement(
+                layer,
+                "Dimension",
+                attrib={
+                    'name': "elevation",
+                    'units': "depth", 
+                    'unitSymbol': elevation_units,
+                    'default': f'{default_elevation}'
+                },
+            )
+            elevation_dimension_element.text = ','.join(elevations)
 
         for style in styles:
             style_element = ET.SubElement(

--- a/xpublish_wms/wms/get_feature_info.py
+++ b/xpublish_wms/wms/get_feature_info.py
@@ -77,13 +77,13 @@ def create_parameter_feature_data(
         values = values.values.round(decimals=5)
         if values.ndim < 2:
             shape.extend([1, 1])
-        else: 
+        else:
             shape = values.shape
         values = values.flatten().tolist()
     elif isinstance(values, np.ndarray):
         if values.ndim < 2:
             shape.extend([1, 1])
-        else: 
+        else:
             shape = values.shape
         values = values.round(decimals=5).flatten().tolist()
     elif values is None:
@@ -124,7 +124,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
 
     elevation_str = query.get("elevation", None)
     if elevation_str == "all":
-        elevation = 'all'
+        elevation = "all"
     elif elevation_str:
         elevation = list([float(e) for e in elevation_str.split("/")])
     else:
@@ -158,7 +158,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
             selected_ds = selected_ds.cf.isel(time=0)
 
     if any_has_vertical_axis:
-        if elevation == 'all':
+        if elevation == "all":
             # Dont select an elevation, just keep all elevation coords
             elevation = selected_ds.cf["vertical"].values
         elif len(elevation) == 1:
@@ -222,7 +222,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
         t_axis = [str(format_timestamp(selected_ds.cf["time"]))]
     else:
         t_axis = format_timestamp(selected_ds.cf["time"]).tolist()
-    
+
     if not any_has_vertical_axis:
         z_axis = None
         elevation_name = None
@@ -319,11 +319,11 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
                                 "name": elevation_name,
                                 "direction": elevation_positive,
                                 "unit": elevation_units,
-                            }
-                        ]
-                    }
-                }
-            }
+                            },
+                        ],
+                    },
+                },
+            },
         )
 
     referencing.append(

--- a/xpublish_wms/wms/get_feature_info.py
+++ b/xpublish_wms/wms/get_feature_info.py
@@ -204,7 +204,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
     elif len(times) == 1:
         t_axis = str(format_timestamp(selected_ds.cf["time"]))
     else:
-        t_axis = str(format_timestamp(selected_ds.cf["time"]))
+        t_axis = format_timestamp(selected_ds.cf["time"]).tolist()
 
     parameter_info = {}
     ranges = {}

--- a/xpublish_wms/wms/get_feature_info.py
+++ b/xpublish_wms/wms/get_feature_info.py
@@ -98,8 +98,10 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
     # Data selection
     if ":" in query["query_layers"]:
         parameters = query["query_layers"].split(":")
+        grouped = True
     else:
         parameters = query["query_layers"].split(",")
+        grouped = False
     time_str = query.get("time", None)
     if time_str:
         times = list(dict.fromkeys([t.replace("Z", "") for t in time_str.split("/")]))
@@ -220,9 +222,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
         ranges[parameter] = range
 
     # For now, hardcoding uv parameter grouping
-    if len(parameters) == 2 and (
-        "u_eastward" in parameters or "u_eastward_max" in parameters
-    ):
+    if len(parameters) == 2 and grouped:
         speed, direction = speed_and_dir_for_uv(
             selected_ds[parameters[0]],
             selected_ds[parameters[1]],

--- a/xpublish_wms/wms/get_feature_info.py
+++ b/xpublish_wms/wms/get_feature_info.py
@@ -202,7 +202,7 @@ def get_feature_info(ds: xr.Dataset, query: dict) -> Response:
     if not any_has_time_axis:
         t_axis = None
     elif len(times) == 1:
-        t_axis = str(format_timestamp(selected_ds.cf["time"]))
+        t_axis = [str(format_timestamp(selected_ds.cf["time"]))]
     else:
         t_axis = format_timestamp(selected_ds.cf["time"]).tolist()
 

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -203,7 +203,8 @@ class GetMap:
         if self.elevation is not None and self.has_elevation:
             da = da.cf.sel({self.ELEVATION_CF_NAME: self.elevation}, method="nearest")
         elif self.has_elevation:
-            da = da.cf.isel({self.ELEVATION_CF_NAME: 0})
+            # Default closest to the surface no matter what
+            da = da.cf.sel({self.ELEVATION_CF_NAME: 0}, method='nearest')
 
         return da
 

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -6,7 +6,7 @@ import xarray as xr
 from fastapi import HTTPException, Response
 from fastapi.responses import JSONResponse
 
-from xpublish_wms.utils import ds_bbox, format_timestamp
+from xpublish_wms.utils import da_bbox, format_timestamp
 
 from .get_map import GetMap
 
@@ -94,7 +94,7 @@ def get_layer_details(ds: xr.Dataset, layer_name: str) -> dict:
     da = ds[layer_name]
     units = da.attrs.get("units", "")
     supported_styles = "raster"  # TODO: more styles
-    bbox = ds_bbox(ds)
+    bbox = da_bbox(da)
     if "vertical" in da.cf:
         elevation = da.cf["vertical"].values.tolist()
         elevation_positive = da.cf["vertical"].attrs.get("positive", "up")


### PR DESCRIPTION
* Enable grouped GFI requests that will compute magnitude and direction params when the layer is defined as `<some_var_x>:<some_var_y>
* Fix time axis formatting for GFI/GetTimeseries requests
* Add missing elevation support to get caps
* Default GetMap and GFI to query at the surface when no elevation has been provided for a 3d dataset
* Add GetVerticalProfile request handler