### PR TITLE
Refactor get_minmax logic to correctly handle bbox selection

### DIFF
--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -483,11 +483,13 @@ def lat_lng_find_quad(lng, lat, lng_values, lat_values):
         ]
 
 
-def mask_data_within_bbox(
-    da: xr.DataArray, bbox: list[float], buffer: Optional[float] = 0.0,
+def filter_data_within_bbox(
+    da: xr.DataArray,
+    bbox: list[float],
+    buffer: Optional[float] = 0.0,
 ) -> xr.DataArray:
     """
-    Mask a DataArray to include only the data within a specified bounding
+    Filter a DataArray to include only the data within a specified bounding
     box, optionally expanded by a buffer.
 
     This function filters the input DataArray based on geographical coordinates,

--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -484,7 +484,7 @@ def lat_lng_find_quad(lng, lat, lng_values, lat_values):
 
 
 def mask_data_within_bbox(
-    da: xr.DataArray, bbox: list[float], buffer: Optional[float] = 0.0
+    da: xr.DataArray, bbox: list[float], buffer: Optional[float] = 0.0,
 ) -> xr.DataArray:
     """
     Mask a DataArray to include only the data within a specified bounding

--- a/xpublish_wms/utils.py
+++ b/xpublish_wms/utils.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from typing import Optional
 
 import cartopy.geodesic
 import numpy as np
@@ -480,3 +481,43 @@ def lat_lng_find_quad(lng, lat, lng_values, lat_values):
             [top_left_index[0][0], top_left_index[1][0]],
             [top_left_index[0][0] + 1, top_left_index[1][0] + 1],
         ]
+
+
+def mask_data_within_bbox(
+    da: xr.DataArray, bbox: list[float], buffer: Optional[float] = 0.0
+) -> xr.DataArray:
+    """
+    Mask a DataArray to include only the data within a specified bounding
+    box, optionally expanded by a buffer.
+
+    This function filters the input DataArray based on geographical coordinates,
+    returning a subset of the data that lies within the given bounding box. The
+    bounding box can be expanded by a specified buffer (in degrees) to ensure
+    inclusivity of data points on the boundaries.
+
+    Parameters:
+    - da (xr.DataArray): The DataArray to be filtered.
+    - bbox (list[float]): A list of four floats representing the geographical
+        bounding box in the order [min_longitude, min_latitude, max_longitude,
+        max_latitude].
+    - buffer (float, optional): The amount by which to expand the bounding box
+        on all sides. Default is 0.0, which means no expansion.
+
+    Returns:
+    - xr.DataArray: The filtered DataArray containing only the data within the
+        expanded bounding box.
+
+    Note:
+    - This function is only meant for use with EPSG:4326 (lon/lat) gridded data.
+    """
+
+    # Get the x and y values
+    x = np.array(da.x.values)
+    y = np.array(da.y.values)
+
+    # Find the indices of the data within the bounding box
+    x_inds = np.where((x >= (bbox[0] - buffer)) & (x <= (bbox[2] + buffer)))[0]
+    y_inds = np.where((y >= (bbox[1] - buffer)) & (y <= (bbox[3] + buffer)))[0]
+
+    # Select and return the data within the bounding box
+    return da.isel(x=x_inds, y=y_inds)

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -15,7 +15,7 @@ import xarray as xr
 from fastapi.responses import StreamingResponse
 
 from xpublish_wms.grids import RenderMethod
-from xpublish_wms.utils import mask_data_within_bbox, parse_float
+from xpublish_wms.utils import filter_data_within_bbox, parse_float
 
 logger = logging.getLogger("uvicorn")
 
@@ -275,7 +275,7 @@ class GetMap:
 
         if minmax_only:
             da = da.persist()
-            data_sel = mask_data_within_bbox(da, self.bbox, self.BBOX_BUFFER)
+            data_sel = filter_data_within_bbox(da, self.bbox, self.BBOX_BUFFER)
 
             try:
                 return {

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -15,7 +15,7 @@ import xarray as xr
 from fastapi.responses import StreamingResponse
 
 from xpublish_wms.grids import RenderMethod
-from xpublish_wms.utils import parse_float
+from xpublish_wms.utils import mask_data_within_bbox, parse_float
 
 logger = logging.getLogger("uvicorn")
 
@@ -30,6 +30,8 @@ class GetMap:
     DEFAULT_CRS: str = "EPSG:3857"
     DEFAULT_STYLE: str = "raster/default"
     DEFAULT_PALETTE: str = "turbo"
+
+    BBOX_BUFFER = 0.18
 
     cache: cachey.Cache
 
@@ -273,18 +275,7 @@ class GetMap:
 
         if minmax_only:
             da = da.persist()
-            x = np.array(da.x.values)
-            y = np.array(da.y.values)
-            data = np.array(da.values)
-            inds = np.where(
-                (x >= (self.bbox[0] - 0.18))
-                & (x <= (self.bbox[2] + 0.18))
-                & (y >= (self.bbox[1] - 0.18))
-                & (y <= (self.bbox[3] + 0.18)),
-            )
-            # x_sel = x[inds].flatten()
-            # y_sel = y[inds].flatten()
-            data_sel = data[inds].flatten()
+            data_sel = mask_data_within_bbox(da, self.bbox, self.BBOX_BUFFER)
 
             try:
                 return {


### PR DESCRIPTION
#### Summary
This MR fixes a bug that was causing `GetMap.get_minmax` to fail when filtering a data layer with a bounding box

Closes https://github.com/xpublish-community/xpublish-wms/issues/80

#### Other details
- Extract BBOX masking logic to a utility function
- Replace BBOX buffer magic numbers with a class attribute
