### PR TITLE
Query Case Insensitivity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,12 @@
 .mypy_cache/
 .pytest_cache/
 .vscode/
+.idea/
 __pycache__/
 build/
 dist/
 xpublish_wms/_version.py
+.env/
+.venv/
 env/
+venv/

--- a/xpublish_wms/grids/fvcom.py
+++ b/xpublish_wms/grids/fvcom.py
@@ -329,7 +329,7 @@ class FVCOMGrid(Grid):
             da = da.cf.isel(vertical=elevation_index)
 
         return da
-    
+
     def additional_coords(self, da):
         filter_dims = ["siglay", "siglev", "nele", "node"]
         return [dim for dim in super().additional_coords(da) if dim not in filter_dims]

--- a/xpublish_wms/grids/fvcom.py
+++ b/xpublish_wms/grids/fvcom.py
@@ -97,7 +97,7 @@ class FVCOMGrid(Grid):
         if "siglay" in subset.dims:
             subset = subset.rename_dims({"siglay": "sigma"})
         elif "siglev" in subset.dims:
-            subset = subset.rename_dims({"siglev": "sigmaa"})
+            subset = subset.rename_dims({"siglev": "sigma"})
 
         if "nele" in subset.dims:
             return self.sel_lat_lng_nele(subset, lng, lat, parameters)
@@ -329,6 +329,10 @@ class FVCOMGrid(Grid):
             da = da.cf.isel(vertical=elevation_index)
 
         return da
+    
+    def additional_coords(self, da):
+        filter_dims = ["siglay", "siglev", "nele", "node"]
+        return [dim for dim in super().additional_coords(da) if dim not in filter_dims]
 
     def project(
         self,

--- a/xpublish_wms/grids/selfe.py
+++ b/xpublish_wms/grids/selfe.py
@@ -200,7 +200,7 @@ class SELFEGrid(Grid):
             da = da.cf.isel(vertical=elevation_index)
 
         return da
-    
+
     def additional_coords(self, da):
         filter_dims = ["siglay", "siglev", "nele", "node"]
         return [dim for dim in super().additional_coords(da) if dim not in filter_dims]

--- a/xpublish_wms/grids/selfe.py
+++ b/xpublish_wms/grids/selfe.py
@@ -200,6 +200,10 @@ class SELFEGrid(Grid):
             da = da.cf.isel(vertical=elevation_index)
 
         return da
+    
+    def additional_coords(self, da):
+        filter_dims = ["siglay", "siglev", "nele", "node"]
+        return [dim for dim in super().additional_coords(da) if dim not in filter_dims]
 
     def project(self, da: xr.DataArray, crs: str) -> any:
         da = self.mask(da)

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -2,25 +2,31 @@ from typing import Annotated, Any, Literal, Optional, Union
 
 from pydantic import AliasChoices, BaseModel, BeforeValidator, Field
 
+
 # https://stackoverflow.com/a/78102277
 class LiteralWrapper:
     def clean_literals(v: Any) -> Any:
         return v
+
     def __class_getitem__(cls, values):
         return Annotated[Literal[values], BeforeValidator(cls.clean_literals)]
+
+
 class LowerLiteral(LiteralWrapper):
     @staticmethod
     def clean_literals(v: Any) -> Any:
         if isinstance(v, str):
             return v.lower().strip()
         return v
+
+
 class UpperLiteral(LiteralWrapper):
     @staticmethod
     def clean_literals(v: Any) -> Any:
         if isinstance(v, str):
             return v.upper().strip()
         return v
-    
+
 
 class WMSBaseQuery(BaseModel):
     service: UpperLiteral["WMS"] = Field(..., description="Service type. Must be WMS")
@@ -43,7 +49,7 @@ class WMSGetMetadataQuery(WMSBaseQuery):
     layername: Optional[str] = Field(
         None,
         description="Name of the layer to get metadata for",
-        validation_alias=AliasChoices("layername", "layers", "query_layers")
+        validation_alias=AliasChoices("layername", "layers", "query_layers"),
     )
     item: LowerLiteral["layerdetails", "timesteps", "minmax", "menu"] = Field(
         ...,
@@ -64,7 +70,7 @@ class WMSGetMetadataQuery(WMSBaseQuery):
     crs: UpperLiteral["EPSG:4326", "EPSG:3857"] = Field(
         "EPSG:4326",
         description="Coordinate reference system to use for the query. EPSG:4326 and EPSG:3857 are supported for this request",
-        validation_alias=AliasChoices("crs", "srs")
+        validation_alias=AliasChoices("crs", "srs"),
     )
     time: Optional[str] = Field(
         None,
@@ -80,7 +86,9 @@ class WMSGetMapQuery(WMSBaseQuery):
     """WMS GetMap query"""
 
     request: LowerLiteral["getmap"] = Field(..., description="Request type")
-    layers: str = Field(validation_alias=AliasChoices("layername", "layers", "query_layers"))
+    layers: str = Field(
+        validation_alias=AliasChoices("layername", "layers", "query_layers"),
+    )
     styles: str = Field(
         "raster/default",
         description="Style to use for the query. Defaults to raster/default. Default may be replaced by the name of any colormap defined by matplotlibs defaults",
@@ -88,7 +96,7 @@ class WMSGetMapQuery(WMSBaseQuery):
     crs: UpperLiteral["EPSG:4326", "EPSG:3857"] = Field(
         "EPSG:4326",
         description="Coordinate reference system to use for the query. EPSG:4326 and EPSG:3857 are supported for this request",
-        validation_alias=AliasChoices("crs", "srs")
+        validation_alias=AliasChoices("crs", "srs"),
     )
     time: Optional[str] = Field(
         None,
@@ -127,11 +135,15 @@ class WMSGetMapQuery(WMSBaseQuery):
 class WMSGetFeatureInfoQuery(WMSBaseQuery):
     """WMS GetFeatureInfo query"""
 
-    request: LowerLiteral["getfeatureinfo", "gettimeseries", "getverticalprofile"] = Field(
-        ...,
-        description="Request type",
+    request: LowerLiteral["getfeatureinfo", "gettimeseries", "getverticalprofile"] = (
+        Field(
+            ...,
+            description="Request type",
+        )
     )
-    query_layers: str = Field(validation_alias=AliasChoices("layername", "layers", "query_layers"))
+    query_layers: str = Field(
+        validation_alias=AliasChoices("layername", "layers", "query_layers"),
+    )
     time: Optional[str] = Field(
         None,
         description="Optional time to get feature info for in Y-m-dTH:M:SZ format. Only valid when the layer has a time dimension. To get a range of times, use 'start/end'",
@@ -143,7 +155,7 @@ class WMSGetFeatureInfoQuery(WMSBaseQuery):
     crs: UpperLiteral["EPSG:4326"] = Field(
         "EPSG:4326",
         description="Coordinate reference system to use for the query. Currently only EPSG:4326 is supported for this request",
-        validation_alias=AliasChoices("crs", "srs")
+        validation_alias=AliasChoices("crs", "srs"),
     )
     bbox: str = Field(
         ...,
@@ -171,7 +183,9 @@ class WMSGetLegendInfoQuery(WMSBaseQuery):
     """WMS GetLegendInfo query"""
 
     request: LowerLiteral["getlegendgraphic"] = Field(..., description="Request type")
-    layers: str = Field(validation_alias=AliasChoices("layername", "layers", "query_layers"))
+    layers: str = Field(
+        validation_alias=AliasChoices("layername", "layers", "query_layers"),
+    )
     width: int
     height: int
     vertical: bool = False
@@ -187,7 +201,7 @@ def parse_wms_query(query_params: dict) -> Union[
     WMSGetFeatureInfoQuery,
     WMSGetLegendInfoQuery,
 ]:
-    request_type = query_params.get('request', None)
+    request_type = query_params.get("request", None)
     if not request_type:
         raise ValueError("Missing WMS 'request' parameter")
     elif not isinstance(request_type, str):

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Literal, Optional, Union
 
 from pydantic import (
@@ -6,7 +5,6 @@ from pydantic import (
     BaseModel,
     Field,
     RootModel,
-    field_validator,
     model_validator,
 )
 

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -1,6 +1,14 @@
-from typing import Any, Literal, Optional, Union
 import json
-from pydantic import AliasChoices, BaseModel, Field, RootModel, model_validator, field_validator
+from typing import Any, Literal, Optional, Union
+
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field,
+    RootModel,
+    field_validator,
+    model_validator,
+)
 
 
 class WMSBaseQuery(BaseModel):
@@ -110,11 +118,9 @@ class WMSGetMapQuery(WMSBaseQuery):
 class WMSGetFeatureInfoQuery(WMSBaseQuery):
     """WMS GetFeatureInfo query"""
 
-    request: Literal["GetFeatureInfo", "GetTimeseries", "GetVerticalProfile"] = (
-        Field(
-            ...,
-            description="Request type",
-        )
+    request: Literal["GetFeatureInfo", "GetTimeseries", "GetVerticalProfile"] = Field(
+        ...,
+        description="Request type",
     )
     query_layers: str = Field(
         validation_alias=AliasChoices("layername", "layers", "query_layers"),
@@ -190,7 +196,7 @@ class WMSQuery(RootModel):
                 ret_v = v
 
                 if isinstance(ret_v, str):
-                    if ret_k == "item": 
+                    if ret_k == "item":
                         ret_v = ret_v.lower()
                     elif ret_k == "crs" or ret_k == "srs":
                         ret_v = ret_v.upper()

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -1,12 +1,6 @@
 from typing import Any, Literal, Optional, Union
 
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    Field,
-    RootModel,
-    model_validator,
-)
+from pydantic import AliasChoices, BaseModel, Field, RootModel, model_validator
 
 
 class WMSBaseQuery(BaseModel):

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -25,7 +25,7 @@ def get_metadata(
     This is compliant subset of ncwms2's GetMetadata handler. Specifically, layerdetails, timesteps and minmax are supported.
     """
     layer_name = query.layername
-    metadata_type = query.item
+    metadata_type = query.item.lower()
 
     if not layer_name and metadata_type != "minmax" and metadata_type != "menu":
         raise HTTPException(


### PR DESCRIPTION
- made `Literals` in query params case insensitive
- made `layers`, `layername`, and `query_layers` all aliases of each other
- made `srs` and `crs` aliases of each other
- added proper filters in `additional_coords` for `selfe` and `fvcom` grid types
- changed `GetLegendInfo.alias` to default to `False`, as it gets set to true anyhow when the request doesn't have a `colorscalerange`