### PR TITLE
Use xarray load_async to make WMS router async

### DIFF
--- a/xpublish_wms/plugin.py
+++ b/xpublish_wms/plugin.py
@@ -33,11 +33,11 @@ class CfWmsPlugin(Plugin):
 
         @router.get("", include_in_schema=False)
         @router.get("/")
-        def wms_root(
+        async def wms_root(
             request: Request,
             dataset: xr.Dataset = Depends(deps.dataset),
             cache: cachey.Cache = Depends(deps.cache),
         ):
-            return wms_handler(request, dataset, cache)
+            return await wms_handler(request, dataset, cache)
 
         return router

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -21,7 +21,7 @@ from .get_metadata import get_metadata
 logger = logging.getLogger("uvicorn")
 
 
-def wms_handler(
+async def wms_handler(
     request: Request,
     dataset: xr.Dataset = Depends(get_dataset),
     cache: cachey.Cache = Depends(get_cache),
@@ -35,7 +35,7 @@ def wms_handler(
         return get_capabilities(dataset, request, query_params)
     elif method == "getmap":
         getmap_service = GetMap(cache=cache)
-        return getmap_service.get_map(dataset, query_params)
+        return await getmap_service.get_map(dataset, query_params)
     elif method == "getfeatureinfo" or method == "gettimeseries":
         return get_feature_info(dataset, query_params)
     elif method == "getverticalprofile":

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -44,7 +44,7 @@ async def wms_handler(
 
     match query:
         case WMSGetCapabilitiesQuery():
-            return await asyncio.to_thread(get_capabilities(dataset, request, query))
+            return await asyncio.to_thread(get_capabilities, dataset, request, query)
         case WMSGetMetadataQuery():
             return await get_metadata(
                 dataset,
@@ -61,10 +61,13 @@ async def wms_handler(
             return await getmap_service.get_map(dataset, query, extra_query_params)
         case WMSGetFeatureInfoQuery():
             return await asyncio.to_thread(
-                get_feature_info(dataset, query, extra_query_params),
+                get_feature_info,
+                dataset,
+                query,
+                extra_query_params,
             )
         case WMSGetLegendInfoQuery():
-            return await asyncio.to_thread(get_legend_info(dataset, query))
+            return await asyncio.to_thread(get_legend_info, dataset, query)
         case _:
             raise HTTPException(
                 status_code=404,

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -2,6 +2,7 @@
 OGC WMS router for datasets with CF convention metadata
 """
 
+import asyncio
 import logging
 
 import cachey
@@ -32,19 +33,19 @@ async def wms_handler(
     logger.info(f"WMS: {method}")
 
     if method == "getcapabilities":
-        return get_capabilities(dataset, request, query_params)
+        return await asyncio.to_thread(get_capabilities, dataset, request, query_params)
     elif method == "getmap":
         getmap_service = GetMap(cache=cache)
         return await getmap_service.get_map(dataset, query_params)
     elif method == "getfeatureinfo" or method == "gettimeseries":
-        return get_feature_info(dataset, query_params)
+        return await asyncio.to_thread(get_feature_info, dataset, query_params)
     elif method == "getverticalprofile":
         query_params["elevation"] = "all"
-        return get_feature_info(dataset, query_params)
+        return await asyncio.to_thread(get_feature_info, dataset, query_params)
     elif method == "getmetadata":
-        return get_metadata(dataset, cache, query_params)
+        return await get_metadata(dataset, cache, query_params)
     elif method == "getlegendgraphic":
-        return get_legend_info(dataset, query_params)
+        return await asyncio.to_thread(get_legend_info, dataset, query_params)
     else:
         raise HTTPException(
             status_code=404,

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -61,12 +61,10 @@ async def wms_handler(
             return await getmap_service.get_map(dataset, query, extra_query_params)
         case WMSGetFeatureInfoQuery():
             return await asyncio.to_thread(
-                get_feature_info(dataset, query, extra_query_params)
+                get_feature_info(dataset, query, extra_query_params),
             )
         case WMSGetLegendInfoQuery():
-            return await asyncio.to_thread(
-                get_legend_info(dataset, query)
-            )
+            return await asyncio.to_thread(get_legend_info(dataset, query))
         case _:
             raise HTTPException(
                 status_code=404,

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -1,4 +1,3 @@
-import asyncio
 import io
 import time
 from datetime import datetime
@@ -138,7 +137,6 @@ class GetMap:
             image_buffer.seek(0)
 
         return StreamingResponse(image_buffer, media_type="image/png")
-
 
     async def get_minmax(
         self,
@@ -378,7 +376,8 @@ class GetMap:
         # if filter_by_bbox was successful, preload data for projection
         if filter_success:
             filter_load_time = time.time()
-            da = da.load()
+            # TODO requires https://github.com/pydata/xarray/pull/10327
+            da = await da.load_async()
             logger.debug(
                 f"WMS GetMap load filtered data: {time.time() - filter_load_time}",
             )

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -286,17 +286,17 @@ class GetMap:
                 # Grab a buffer around the bbox to ensure we have enough data to render
                 # TODO: Base this on actual data resolution?
                 if self.crs == "EPSG:4326":
-                    buffer = 0.5  # degrees
+                    coord_buffer = 0.5  # degrees
                 elif self.crs == "EPSG:3857":
-                    buffer = 30000  # meters
+                    coord_buffer = 30000  # meters
                 else:
                     # Default to 0.5, this should never happen
-                    buffer = 0.5
+                    coord_buffer = 0.5
 
                 # Filter the data to only include the data within the bbox + buffer so
                 # we don't have to render a ton of empty space or pull down more chunks
                 # than we need
-                da = filter_data_within_bbox(da, self.bbox, buffer)
+                da = filter_data_within_bbox(da, self.bbox, coord_buffer)
             except Exception as e:
                 logger.error(f"Error filtering data within bbox: {e}")
                 logger.warning("Falling back to full layer")

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -43,12 +43,12 @@ async def get_metadata(
         )
 
     if metadata_type == "menu":
-        payload = asyncio.to_thread(get_menu(ds))
+        payload = asyncio.to_thread(get_menu, ds)
     elif metadata_type == "layerdetails":
-        payload = asyncio.to_thread(get_layer_details(ds, layer_name))
+        payload = asyncio.to_thread(get_layer_details, ds, layer_name)
     elif metadata_type == "timesteps":
         da = ds[layer_name]
-        payload = asyncio.to_thread(get_timesteps(da, query))
+        payload = asyncio.to_thread(get_timesteps, da, query)
     elif metadata_type == "minmax":
         payload = await get_minmax(
             ds,

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -11,7 +11,7 @@ from xpublish_wms.utils import format_timestamp
 from .get_map import GetMap
 
 
-def get_metadata(ds: xr.Dataset, cache: cachey.Cache, params: dict) -> Response:
+async def get_metadata(ds: xr.Dataset, cache: cachey.Cache, params: dict) -> Response:
     """
     Return the WMS metadata for the dataset
 
@@ -39,7 +39,7 @@ def get_metadata(ds: xr.Dataset, cache: cachey.Cache, params: dict) -> Response:
         da = ds[layer_name]
         payload = get_timesteps(da, params)
     elif metadata_type == "minmax":
-        payload = get_minmax(ds, cache, params)
+        payload = await get_minmax(ds, cache, params)
     else:
         raise HTTPException(
             status_code=400,
@@ -79,14 +79,14 @@ def get_timesteps(da: xr.DataArray, params: dict) -> dict:
     }
 
 
-def get_minmax(ds: xr.Dataset, cache: cachey.Cache, params: dict) -> dict:
+async def get_minmax(ds: xr.Dataset, cache: cachey.Cache, params: dict) -> dict:
     """
     Returns the min and max range of values for a given layer in a given area
 
     If BBOX is not specified, the entire selected temporal and elevation range is used.
     """
     getmap = GetMap(cache=cache)
-    return getmap.get_minmax(ds, params)
+    return await getmap.get_minmax(ds, params)
 
 
 def get_layer_details(ds: xr.Dataset, layer_name: str) -> dict:

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -43,12 +43,12 @@ async def get_metadata(
         )
 
     if metadata_type == "menu":
-        payload = asyncio.to_thread(get_menu, ds)
+        payload = await asyncio.to_thread(get_menu, ds)
     elif metadata_type == "layerdetails":
-        payload = asyncio.to_thread(get_layer_details, ds, layer_name)
+        payload = await asyncio.to_thread(get_layer_details, ds, layer_name)
     elif metadata_type == "timesteps":
         da = ds[layer_name]
-        payload = asyncio.to_thread(get_timesteps, da, query)
+        payload = await asyncio.to_thread(get_timesteps, da, query)
     elif metadata_type == "minmax":
         payload = await get_minmax(
             ds,

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -1,5 +1,5 @@
-import datetime as dt
 import asyncio
+import datetime as dt
 
 import cachey
 import cf_xarray  # noqa


### PR DESCRIPTION
Builds on @mpiannucci 's PR #98 but instead uses the (as yet unmerged) xarray PR https://github.com/pydata/xarray/pull/10327 which adds `da.load_async`, which should work when lazily loading zarr data using zarr-python v3 without dask.

> This also introduces clipping for GetMap requests

I deleted this part of #98 because it seemed separable.