### PR TITLE
GetFeatureInfo Time Fix

### DIFF
--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -50,7 +50,7 @@ def validate_bbox(v: str | None) -> tuple[float, float, float, float] | None:
     if v is None:
         return None
 
-    values = v.split(",")
+    values = v.split(",") if isinstance(v, str) else v
     if len(values) != 4:
         raise ValueError("bbox must be in the format 'minx,miny,maxx,maxy'")
 

--- a/xpublish_wms/wms/get_feature_info.py
+++ b/xpublish_wms/wms/get_feature_info.py
@@ -178,7 +178,7 @@ def get_feature_info(
         ):
             selected_ds = selected_ds.cf.isel(time=0)
         elif len(times) == 1:
-            selected_ds = selected_ds.cf.interp(time=times[0])
+            selected_ds = selected_ds.cf.sel(time=times[0], method="nearest")
         elif len(times) > 1:
             selected_ds = selected_ds.cf.sel(time=slice(times[0], times[1]))
         else:


### PR DESCRIPTION
when using an icechunk dataset with a lot of timesteps (300000+), the `interp` function fails, being unable to allocate an appropriate amount of memory