### PR TITLE
Triangular Grid Filter/Projection Fixes

### DIFF
--- a/xpublish_wms/grids/triangular.py
+++ b/xpublish_wms/grids/triangular.py
@@ -296,7 +296,7 @@ class TriangularGrid(Grid):
                 bbox[2] -= 360
                 render_context["cross_dateline"] = True
 
-        # filter by our two seperate negative/positive lng ranges
+        # filter by our two separate negative/positive lng ranges
         # if dateline was crossed
         if render_context.get("cross_dateline", False):
             x = np.where((x >= bbox[0]) | (x <= bbox[2]))[0]

--- a/xpublish_wms/grids/triangular.py
+++ b/xpublish_wms/grids/triangular.py
@@ -185,6 +185,7 @@ class TriangularGrid(Grid):
         )
         lng_tris = lng[np.array(e.flat) - 1].values.reshape(e.shape)
 
+        # check for tris that cross the dateline
         cross_inds = np.where(
             np.logical_and(
                 np.min(lng_tris, axis=1) < -90,
@@ -192,9 +193,38 @@ class TriangularGrid(Grid):
             ),
         )[0]
         if cross_inds.shape[0] > 0:
-            unique_inds = np.unique(e[cross_inds].flat) - 1
-            update_inds = unique_inds[np.where(lng[unique_inds] < 0)[0]]
-            lng[update_inds] = lng[update_inds] + 360
+            if render_context.get("cross_dateline", False):
+                # if any tris cross the dateline and we actually want that data, 
+                # add/subtract 360 from all positive or negative vertices, 
+                # whichever results in less vertices being updated
+                
+                # all lng_tris with at least one negative vertex
+                negative_inds = np.where(
+                    np.min(lng_tris, axis=1) < 0
+                )[0]
+                # all lng_tris with at least one positive vertex
+                positive_inds = np.where(
+                    np.max(lng_tris, axis=1) > 0
+                )[0]
+
+                if negative_inds.shape[0] > positive_inds.shape[0]:
+                    # subtract 360 from all the positive inds
+                    unique_inds = np.unique(e[positive_inds].flat) - 1
+                    update_inds = unique_inds[np.where(lng[unique_inds] > 0)[0]]
+                    lng[update_inds] -= 360
+                else:
+                    # add 360 to all the negative inds
+                    unique_inds = np.unique(e[negative_inds].flat) - 1
+                    update_inds = unique_inds[np.where(lng[unique_inds] < 0)[0]]
+                    lng[update_inds] += 360
+            else:
+                # if we don't actually need the data across the dateline
+                # (eg. global tiles), just update the triangles that actually
+                # cross the dateline itself 
+                unique_inds = np.unique(e[cross_inds].flat) - 1
+                update_inds = unique_inds[np.where(lng[unique_inds] < 0)[0]]
+                lng[update_inds] = lng[update_inds] + 360
+            
             da.__setitem__(da.cf["longitude"].name, lng)
 
         if crs == "EPSG:4326":
@@ -258,7 +288,25 @@ class TriangularGrid(Grid):
         y = da.cf["latitude"]
         e = self.ds.element.values.astype(int)
 
-        x = np.where((x >= bbox[0]) & (x <= bbox[2]))[0]
+        # because our bbox lng can go beyond the traditional [-180, 180] bounds
+        # we must adjust back to [-180, 180] so that data isn't excluded
+        if not (bbox[0] < -180 and bbox[2] > 180):
+            # if both bbox[0] and bbox[2] exceed the bounds (ex. global tile),
+            # we will get everything between [-180, 180] regardless
+            if bbox[0] < -180: 
+                bbox[0] += 360
+                render_context["cross_dateline"] = True
+            if bbox[2] > 180:
+                bbox[2] -= 360
+                render_context["cross_dateline"] = True
+
+        # filter by our two seperate negative/positive lng ranges 
+        # if dateline was crossed
+        if render_context.get("cross_dateline", False):
+            x = np.where((x >= bbox[0]) | (x <= bbox[2]))[0]
+        else:
+            x = np.where((x >= bbox[0]) & (x <= bbox[2]))[0]
+        
         y = np.where((y >= bbox[1]) & (y <= bbox[3]))[0]
 
         e_ind = np.intersect1d(x, y) + 1

--- a/xpublish_wms/grids/triangular.py
+++ b/xpublish_wms/grids/triangular.py
@@ -194,18 +194,14 @@ class TriangularGrid(Grid):
         )[0]
         if cross_inds.shape[0] > 0:
             if render_context.get("cross_dateline", False):
-                # if any tris cross the dateline and we actually want that data, 
-                # add/subtract 360 from all positive or negative vertices, 
+                # if any tris cross the dateline and we actually want that data,
+                # add/subtract 360 from all positive or negative vertices,
                 # whichever results in less vertices being updated
-                
+
                 # all lng_tris with at least one negative vertex
-                negative_inds = np.where(
-                    np.min(lng_tris, axis=1) < 0
-                )[0]
+                negative_inds = np.where(np.min(lng_tris, axis=1) < 0)[0]
                 # all lng_tris with at least one positive vertex
-                positive_inds = np.where(
-                    np.max(lng_tris, axis=1) > 0
-                )[0]
+                positive_inds = np.where(np.max(lng_tris, axis=1) > 0)[0]
 
                 if negative_inds.shape[0] > positive_inds.shape[0]:
                     # subtract 360 from all the positive inds
@@ -220,11 +216,11 @@ class TriangularGrid(Grid):
             else:
                 # if we don't actually need the data across the dateline
                 # (eg. global tiles), just update the triangles that actually
-                # cross the dateline itself 
+                # cross the dateline itself
                 unique_inds = np.unique(e[cross_inds].flat) - 1
                 update_inds = unique_inds[np.where(lng[unique_inds] < 0)[0]]
                 lng[update_inds] = lng[update_inds] + 360
-            
+
             da.__setitem__(da.cf["longitude"].name, lng)
 
         if crs == "EPSG:4326":
@@ -293,20 +289,20 @@ class TriangularGrid(Grid):
         if not (bbox[0] < -180 and bbox[2] > 180):
             # if both bbox[0] and bbox[2] exceed the bounds (ex. global tile),
             # we will get everything between [-180, 180] regardless
-            if bbox[0] < -180: 
+            if bbox[0] < -180:
                 bbox[0] += 360
                 render_context["cross_dateline"] = True
             if bbox[2] > 180:
                 bbox[2] -= 360
                 render_context["cross_dateline"] = True
 
-        # filter by our two seperate negative/positive lng ranges 
+        # filter by our two seperate negative/positive lng ranges
         # if dateline was crossed
         if render_context.get("cross_dateline", False):
             x = np.where((x >= bbox[0]) | (x <= bbox[2]))[0]
         else:
             x = np.where((x >= bbox[0]) & (x <= bbox[2]))[0]
-        
+
         y = np.where((y >= bbox[1]) & (y <= bbox[3]))[0]
 
         e_ind = np.intersect1d(x, y) + 1


### PR DESCRIPTION
There are two separate fixes introduced here:

#129 introduced an expanded "buffer" to the request bbox so that enough data was kept during the filtering process. However, this buffer allowed the bbox to extend beyond the traditional [-180, 180] lng extents, and this was not accounted for in `filter_by_bbox()`. As an example, an input bbox with lngs [120, 180] might be expanded by the buffer into [115, 185], but because the dataset is normalized to [-180, 180] before filtering, all the data between lngs 180 - 185 is never actually included in the filtered data. This fix accounts for this by wrapping around the lngs that exceed the bounds (ex. lngs [180 - 185] to lngs [-180, -175]), and then including that new data in the filter as well.

This problem is actually present in most of the other grids, but it only really makes a difference for grids like triangular where the points outside of the bounds being included actually improves how the tile looks on the edge of the dateline. Even then, the difference is marginal (see before/after below), and it might not really be worth it if this fix causes other complications.
![Screenshot 2025-05-29 135608](https://github.com/user-attachments/assets/5071afb6-8b54-48f4-8d37-8a73401434f6)
![Screenshot 2025-05-29 135058](https://github.com/user-attachments/assets/c0810580-298f-4646-ae8f-9e8310a9df18)

The other problem presented in these smeared tiles that you would often see just to the right of the date line:
![Screenshot 2025-05-21 162640](https://github.com/user-attachments/assets/19546a84-2e8e-4c78-affc-c1e68de43dab)

This was caused by a bug in `project()` when trying to account for triangles that cross the dateline by adding 360 to all negative points on triangles with both negative and positive lng values. The problem was that this fixed the triangles that actually cross the date line, but not the triangles that are completely on the other side of the date line (ex. three negative vertices when all vertices should be positive). So those triangles were smearing across the entire tile by having negative coordinates on a tile that should be entirely positive. 

The fix here was to check if any triangles cross the dateline, then update all the positive/negative vertices if at least one does, instead of just the vertices that are actually part of the triangles that cross the dateline. Note that I did need to add an exception here for global tiles (tiles that encompass the entire [-180, 180] lng range) to allow them to render correctly while having triangles that crossed the dateline on both the left/right edges of a tile at the same time.