### PR TITLE
Add multi-layer vector tile support

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,5 @@
 import pytest
+import xarray as xr
 
 from xpublish_wms.query import (
     WMSGetCapabilitiesQuery,
@@ -8,6 +9,7 @@ from xpublish_wms.query import (
     WMSGetMetadataQuery,
     WMSQuery,
 )
+from xpublish_wms.wms.get_map.main import GetMap
 
 
 def test_wms_query_discriminator():
@@ -209,3 +211,63 @@ def test_wms_query_discriminator():
         styles="raster/default",
     )
     assert isinstance(getlegendinfo_query.root, WMSGetLegendInfoQuery)
+
+
+@pytest.mark.parametrize("opt", ["colormap", "default", "magma"])
+def test_get_map_colormap(opt):
+    getmap_query = WMSGetMapQuery.model_validate(
+        {
+            "service": "WMS",
+            "version": "1.3.0",
+            "request": "GetMap",
+            "layers": "layer1",
+            "styles": f"raster/{opt}",
+            "crs": "EPSG:3857",
+            "tile": "1,1,1",
+            "width": 100,
+            "height": 100,
+            "colorscalerange": "0,100",
+            "autoscale": True,
+        },
+    )
+    request = GetMap(cache=None, array_render_threshold_bytes=1e9)
+    request.ensure_query_types(xr.Dataset({"layer1": [1, 2, 3]}), getmap_query, {})
+    assert request.styles.type == "colormap"
+    assert request.styles.palettename is not None
+    assert (
+        request.styles.palettename != "colormap"
+        and request.styles.palettename != "default"
+    )
+
+
+def test_get_map_vectors():
+    for style in [
+        "vector-arrow/none",
+        "vector-arrow/default",
+        "vector-arrow-color/default",
+    ]:
+        getmap_query = WMSGetMapQuery.model_validate(
+            {
+                "service": "WMS",
+                "version": "1.3.0",
+                "request": "GetMap",
+                "layers": "u,v",
+                "styles": style,
+                "crs": "EPSG:3857",
+                "tile": "1,1,1",
+                "width": 100,
+                "height": 100,
+                "colorscalerange": "0,100",
+                "autoscale": True,
+                "density": 3,
+            },
+        )
+        request = GetMap(cache=None, array_render_threshold_bytes=1e9)
+        request.ensure_query_types(
+            xr.Dataset({"u": [1, 2, 3], "v": [1, 2, 3]}),
+            getmap_query,
+            {},
+        )
+        assert request.styles.type == "vector"
+        assert request.styles.color == "black"
+        assert request.styles.density == 3

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, Union
+from typing import Any, List, Literal, Optional, Self, Union
 
 from pydantic import (
     AliasChoices,
@@ -77,6 +77,19 @@ def validate_style(v: str | None) -> tuple[str, str] | None:
     return (values[0], values[1])
 
 
+LAYER_DELIMITER = ","
+
+
+def validate_layers(layers_str: str | None) -> List[str] | None:
+    """Parse layer name list and validate it."""
+    if layers_str is None:
+        return None
+    layers = layers_str.split(LAYER_DELIMITER)
+    if len(layers) > 2:
+        raise ValueError("More than two layers are not supported")
+    return layers
+
+
 class WMSBaseQuery(BaseModel):
     service: Literal["WMS"] = Field(..., description="Service type. Must be WMS")
     version: Literal["1.1.1", "1.3.0"] = Field(
@@ -95,7 +108,7 @@ class WMSGetMetadataQuery(WMSBaseQuery):
     """WMS GetMetadata query"""
 
     request: Literal["GetMetadata"] = Field(..., description="Request type")
-    layername: Optional[str] = Field(
+    layers: Optional[List[str]] = Field(
         None,
         description="Name of the layer to get metadata for",
         validation_alias=AliasChoices("layername", "layers", "query_layers"),
@@ -135,17 +148,42 @@ class WMSGetMetadataQuery(WMSBaseQuery):
     def validate_bbox(cls, v: str | None) -> tuple[float, float, float, float] | None:
         return validate_bbox(v)
 
+    @field_validator("layers", mode="before")
+    @classmethod
+    def validate_layers(cls, val: str | None) -> List[str] | None:
+        return validate_layers(val)
+
+
+# Future styles might include:
+# - vector-arrow-tail/none (magnitude visualized by arrow tail length),
+# - vector-arrow-scale/none (magnitude visualized by uniform arrow scaling),
+# - vector-barb/none
+GetMapStyleMethod = Literal["raster", "vector-arrow", "vector-arrow-color"]
+GET_MAP_STYLE_METHODS: List[GetMapStyleMethod] = [
+    "raster",
+    "vector-arrow",
+    "vector-arrow-color",
+]
+
 
 class WMSGetMapQuery(WMSBaseQuery):
     """WMS GetMap query"""
 
     request: Literal["GetMap"] = Field(..., description="Request type")
-    layers: str = Field(
+    layers: List[str] = Field(
         validation_alias=AliasChoices("layername", "layers", "query_layers"),
     )
-    styles: tuple[str, str] = Field(
+    styles: tuple[GetMapStyleMethod, Literal["none"] | str] = Field(
         ("raster", "default"),
-        description="Style to use for the query. Defaults to raster/default. Default may be replaced by the name of any colormap defined by matplotlibs defaults",
+        description=(
+            "Style to use for the query. Options: 'raster/<colormap>', 'vector-arrow/none', "
+            "'vector-arrow/<colormap>', 'vector-arrow-color/<colormap>'. You can provide "
+            "a name of any colormap defined by matplotlib's defaults directly like 'raster/turbo'. "
+            "For vector tiles, 'vector-arrow/<colormap> renders directional arrows with "
+            "raster backing visualizing magnitude. 'vector-arrow/none' can be used for arrows only. "
+            "Passing 'raster/default' uses the default colormap. "
+            "This parameter defaults to 'raster/default'."
+        ),
     )
     crs: Literal["EPSG:4326", "EPSG:3857"] = Field(
         "EPSG:4326",
@@ -184,6 +222,21 @@ class WMSGetMapQuery(WMSBaseQuery):
         False,
         description="Whether to automatically scale the color scale range based on the data. When specified, colorscalerange is ignored",
     )
+    color: str = Field(
+        "black",
+        description="Color of directional glyphs when using a vector style. This is a matplotlib color parameter.",
+    )
+    density: int | None = Field(
+        None,
+        description="Density of directional glyphs when using a vector style.",
+        ge=1,
+        le=3,
+    )
+
+    @field_validator("layers", mode="before")
+    @classmethod
+    def validate_layers(cls, val: str | None) -> List[str] | None:
+        return validate_layers(val)
 
     @field_validator("colorscalerange", mode="before")
     @classmethod
@@ -206,18 +259,22 @@ class WMSGetMapQuery(WMSBaseQuery):
         return validate_style(v)
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_dependent_colorscalerange(
-        cls,
-        v: "WMSGetMapQuery",
-    ) -> "WMSGetMapQuery":
-        if v.colorscalerange is None and not v.autoscale:
+    def validate_dependent_parameters(self) -> Self:
+        if self.colorscalerange is None and not self.autoscale:
             raise ValueError("colorscalerange is required when autoscale is False")
-        if v.bbox is None and v.tile is None:
+        if self.bbox is None and self.tile is None:
             raise ValueError("bbox or tile must be specified")
-        if v.tile is not None and v.crs != "EPSG:3857":
+        if self.tile is not None and self.crs != "EPSG:3857":
             raise ValueError("tile is only supported for EPSG:3857")
-        return v
+        if self.styles[0].startswith("raster") and len(self.layers) != 1:
+            raise ValueError(
+                "Raster styles require exactly 1 layer",
+            )
+        if self.styles[0].startswith("vector") and len(self.layers) != 2:
+            raise ValueError(
+                "Vector styles require exactly 2 layers (u and v components)",
+            )
+        return self
 
 
 class WMSGetFeatureInfoQuery(WMSBaseQuery):
@@ -274,7 +331,8 @@ class WMSGetLegendInfoQuery(WMSBaseQuery):
     """WMS GetLegendInfo query"""
 
     request: Literal["GetLegendGraphic"] = Field(..., description="Request type")
-    layers: str = Field(
+    layers: Optional[str] = Field(
+        None,
         validation_alias=AliasChoices("layername", "layers", "query_layers"),
     )
     width: int
@@ -351,6 +409,8 @@ WMS_FILTERED_QUERY_PARAMS = {
     "height",
     "colorscalerange",
     "autoscale",
+    "color",
+    "density",
     "item",
     "day",
     "range",

--- a/xpublish_wms/wms/__init__.py
+++ b/xpublish_wms/wms/__init__.py
@@ -61,7 +61,7 @@ def wms_handler(
         case WMSGetFeatureInfoQuery():
             return get_feature_info(dataset, query, extra_query_params)
         case WMSGetLegendInfoQuery():
-            return get_legend_info(dataset, query)
+            return get_legend_info(query)
         case _:
             raise HTTPException(
                 status_code=404,

--- a/xpublish_wms/wms/get_legend_info.py
+++ b/xpublish_wms/wms/get_legend_info.py
@@ -2,40 +2,22 @@ import io
 
 import matplotlib
 import numpy as np
-import xarray as xr
 from fastapi import Response
 from PIL import Image
 
 from xpublish_wms.query import WMSGetLegendInfoQuery
 
 
-def get_legend_info(dataset: xr.Dataset, query: WMSGetLegendInfoQuery) -> Response:
+def get_legend_info(query: WMSGetLegendInfoQuery) -> Response:
     """
     Return the WMS legend graphic for the dataset and given parameters
     """
-    parameter = query.layers
     width = query.width
     height = query.height
     vertical = query.vertical
-    # colorbaronly = query.get("colorbaronly", "False") == "True"
-    colorscalerange = query.colorscalerange
-    autoscale = query.autoscale
-    stylename, palettename = query.styles
+    _, palettename = query.styles
 
-    ds = dataset.squeeze()
-
-    # if the user has supplied a color range, use it. Otherwise autoscale
-    if autoscale:
-        min_value = float(ds[parameter].min())
-        max_value = float(ds[parameter].max())
-    else:
-        min_value = colorscalerange[0]
-        max_value = colorscalerange[1]
-
-    scaled = (np.linspace(min_value, max_value, width) - min_value) / (
-        max_value - min_value
-    )
-    data = np.ones((height, width)) * scaled
+    data = np.ones((height, width)) * np.linspace(0, 1, width)
 
     if vertical:
         data = np.flipud(data.T)

--- a/xpublish_wms/wms/get_map.py
+++ b/xpublish_wms/wms/get_map.py
@@ -1,7 +1,7 @@
 import io
 import time
 from datetime import datetime
-from typing import List, Union
+from typing import List, Sequence, Union
 
 import cachey
 import cf_xarray  # noqa
@@ -52,7 +52,7 @@ class GetMap:
 
     # Output style
     style: str
-    colorscalerange: List[float]
+    colorscalerange: Sequence[float] | None
     autoscale: bool
 
     def __init__(
@@ -207,7 +207,23 @@ class GetMap:
         self.height = query.height
 
         # Output style
-        _, self.palettename = query.styles
+        self.decode_query_styles(query)
+
+        available_selectors = ds.gridded.additional_coords(ds[self.parameter])
+        self.dim_selectors = {
+            k: query_params[k] if k in query_params else None
+            for k in available_selectors
+        }
+
+    def decode_query_styles(self, query: WMSGetMapQuery):
+        """
+        Decode request parameters related to render style
+        """
+        _, raster_style = query.styles
+        # TODO: add more style options
+        self.style = "colormap"
+
+        self.palettename = raster_style
         # Let user pick cm from here https://predictablynoisy.com/matplotlib/gallery/color/colormap_reference.html#sphx-glr-gallery-color-colormap-reference-py
         # Otherwise default to rainbow
         if self.palettename == "default":
@@ -216,11 +232,6 @@ class GetMap:
         self.colorscalerange = query.colorscalerange
         self.autoscale = query.autoscale
 
-        available_selectors = ds.gridded.additional_coords(ds[self.parameter])
-        self.dim_selectors = {
-            k: query_params[k] if k in query_params else None
-            for k in available_selectors
-        }
 
     def select_layer(self, ds: xr.Dataset) -> xr.DataArray:
         """
@@ -434,19 +445,27 @@ class GetMap:
                 )
                 return {"min": float(da.min()), "max": float(da.max())}
 
-        if not self.autoscale:
-            span = (self.colorscalerange[0], self.colorscalerange[1])
-        else:
-            span = None
-
         start_mesh = time.time()
-        cvs = dsh.Canvas(
-            plot_height=self.height,
-            plot_width=self.width,
-            x_range=(self.bbox[0], self.bbox[2]),
-            y_range=(self.bbox[1], self.bbox[3]),
-        )
+        mesh = self.create_mesh(ds, da, render_context=render_context)
+        logger.debug(f"WMS GetMap Mesh time: {time.time() - start_mesh}")
 
+        start_shade = time.time()
+        shaded = self.shade_mesh(mesh, )
+        logger.debug(f"WMS GetMap Shade time: {time.time() - start_shade}")
+
+        im = shaded.to_pil()
+        im.save(buffer, format="PNG")
+        return True
+    
+    def create_mesh(
+        self,
+        ds: xr.Dataset,
+        da: xr.DataArray,
+        render_context: dict,
+    ) -> xr.Dataset:
+        """
+        Create map mesh
+        """
         # numba only supports float32 and float64. Cast everything else
         if da.dtype.kind == "f" and da.dtype.itemsize != 4 and da.dtype.itemsize != 8:
             logger.warning(
@@ -469,23 +488,32 @@ class GetMap:
                     f"greater than 64-bit. This is not currently supported.",
                 )
 
+        cvs = dsh.Canvas(
+            plot_height=self.height,
+            plot_width=self.width,
+            x_range=(self.bbox[0], self.bbox[2]),
+            y_range=(self.bbox[1], self.bbox[3]),
+        )
+
         if ds.gridded.render_method == RenderMethod.Raster:
-            mesh = cvs.raster(
+            return cvs.raster(
                 da,
             )
-        elif ds.gridded.render_method == RenderMethod.Quad:
+
+        if ds.gridded.render_method == RenderMethod.Quad:
             try:
-                mesh = cvs.quadmesh(
+                return cvs.quadmesh(
                     da,
                     x="x",
                     y="y",
                 )
             except Exception as e:
                 logger.warning(f"Error rendering quadmesh: {e}, falling back to raster")
-                mesh = cvs.raster(
+                return cvs.raster(
                     da,
                 )
-        elif ds.gridded.render_method == RenderMethod.Triangle:
+
+        if ds.gridded.render_method == RenderMethod.Triangle:
             triangles, render_context = ds.gridded.tessellate(
                 da,
                 render_context=render_context,
@@ -504,21 +532,25 @@ class GetMap:
                 verts = pd.DataFrame({"x": da.x, "y": da.y, "z": da})
                 tris = pd.DataFrame(triangles.astype(int), columns=["v0", "v1", "v2"])
 
-            mesh = cvs.trimesh(
+            return cvs.trimesh(
                 verts,
                 tris,
             )
-        logger.debug(f"WMS GetMap Mesh time: {time.time() - start_mesh}")
 
-        start_shade = time.time()
-        shaded = tf.shade(
-            mesh,
-            cmap=matplotlib.colormaps.get_cmap(self.palettename),
-            how="linear",
-            span=span,
-        )
-        logger.debug(f"WMS GetMap Shade time: {time.time() - start_shade}")
-
-        im = shaded.to_pil()
-        im.save(buffer, format="PNG")
-        return True
+        raise ValueError(f"Unexpected gridded dataset render method {ds.gridded.render_method}")
+    
+    def shade_mesh(self, mesh: xr.Dataset):
+        if self.style == "colormap":
+            span = (
+                None
+                if self.autoscale or self.colorscalerange is None
+                else tuple(self.colorscalerange[0:2])
+            )
+            return tf.shade(
+                mesh,
+                cmap=matplotlib.colormaps.get_cmap(self.palettename),
+                how="linear",
+                span=span,
+            )
+        # TODO other styles
+        raise NotImplementedError(f"{self.style} is not implemented yet")

--- a/xpublish_wms/wms/get_map/__init__.py
+++ b/xpublish_wms/wms/get_map/__init__.py
@@ -1,0 +1,5 @@
+"""GetMap request handling."""
+
+from xpublish_wms.wms.get_map.main import GetMap
+
+__all__ = ["GetMap"]

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -1,7 +1,8 @@
 import io
 import time
 from datetime import datetime
-from typing import List, Sequence, Union
+from functools import partial
+from typing import Iterable, List, Sequence, Union
 
 import cachey
 import cf_xarray  # noqa
@@ -14,10 +15,17 @@ import pandas as pd
 import xarray as xr
 from fastapi import HTTPException
 from fastapi.responses import Response
+from PIL.Image import Image
 
 from xpublish_wms.grids import RenderMethod
 from xpublish_wms.logger import logger
 from xpublish_wms.query import WMSGetMapQuery
+from xpublish_wms.wms.get_map.style_types import (
+    ColormapStyleParams,
+    ShadingStyleParams,
+    VectorStyleParams,
+)
+from xpublish_wms.wms.get_map.vector_styles import visualize_vectors
 
 
 class GetMap:
@@ -37,7 +45,7 @@ class GetMap:
     array_render_threshold_bytes: int
 
     # Data selection
-    parameter: str
+    parameters: list[str]
     time: datetime = None
     has_time: bool
     elevation: float = None
@@ -51,9 +59,7 @@ class GetMap:
     height: int
 
     # Output style
-    style: str
-    colorscalerange: Sequence[float] | None
-    autoscale: bool
+    styles: ShadingStyleParams
 
     def __init__(
         self,
@@ -72,6 +78,7 @@ class GetMap:
         """
         Return the WMS map for the dataset and given parameters
         """
+        start_get_map = time.time()
         # Decode request params
         try:
             self.ensure_query_types(ds, query, query_params)
@@ -84,7 +91,7 @@ class GetMap:
 
         # Select data according to request
         try:
-            da = self.select_layer(ds)
+            das = self.select_layers(ds)
         except Exception as e:
             logger.error(f"Error selecting layer: {e}")
             raise HTTPException(
@@ -93,7 +100,7 @@ class GetMap:
             )
 
         try:
-            da = self.select_time(da)
+            das = [self.select_time(da) for da in das]
         except Exception as e:
             logger.error(f"Error selecting time: {e}")
             raise HTTPException(
@@ -102,7 +109,7 @@ class GetMap:
             )
 
         try:
-            da = self.select_elevation(ds, da)
+            das = [self.select_elevation(ds, da) for da in das]
         except Exception as e:
             logger.error(f"Error selecting elevation: {e}")
             raise HTTPException(
@@ -111,7 +118,7 @@ class GetMap:
             )
 
         try:
-            da = self.select_custom_dim(da)
+            das = [self.select_custom_dim(da) for da in das]
         except Exception as e:
             logger.error(f"Error selecting custom dimensions: {e}")
             raise HTTPException(
@@ -125,7 +132,7 @@ class GetMap:
         # use the contoured renderer for regular grid datasets
         image_buffer = io.BytesIO()
         try:
-            render_result = self.render(ds, da, image_buffer, False)
+            render_result = self.render(ds, das, image_buffer, False)
         except HTTPException as e:
             raise e
         except Exception as e:
@@ -138,6 +145,7 @@ class GetMap:
         if render_result:
             image_buffer.seek(0)
 
+        logger.debug(f"WMS GetMap TOTAL time: {time.time() - start_get_map}")
         return Response(image_buffer.getbuffer(), media_type="image/png")
 
     def get_minmax(
@@ -154,17 +162,43 @@ class GetMap:
         self.ensure_query_types(ds, query, query_params)
 
         # Select data according to request
-        da = self.select_layer(ds)
-        da = self.select_time(da)
-        da = self.select_elevation(ds, da)
-        da = self.select_custom_dim(da)
+        das = self.select_layers(ds)
+        selectors = [
+            self.select_time,
+            partial(self.select_elevation, ds),
+            self.select_custom_dim,
+        ]
+        for selector in selectors:
+            das = [selector(da) for da in das]
 
         # Prepare the data as if we are going to render it, but instead grab the min and max
         # values from the data to represent the range of values in the given area
-        if entire_layer:
+        filtered_das = (
+            das if entire_layer else self.render(ds, das, None, minmax_only=True)
+        )
+        if isinstance(filtered_das, bool):
+            # render method returned False because the filtered DataArray was empty
+            return {"min": 0, "max": 0}
+
+        # Get one DataArray from one or more
+        da = das_to_scalar(filtered_das)
+
+        try:
+            # `da` seems to be lazy and when accessed here for a computed magnitude
+            # of vector component layers, we can run into allocation errors.
             return {"min": float(da.min()), "max": float(da.max())}
-        else:
-            return self.render(ds, da, None, minmax_only=True)
+        except MemoryError as err:
+            logger.error(
+                f"Failed to allocate enough memory to calculate min/max: {err}",
+            )
+            if len(filtered_das) == 2:
+                # for vector layers, try to calculate a ceiling of the magnitude as a fallback
+                max_x, max_y = (np.abs(da).max() for da in filtered_das)
+                ceiling = float(np.sqrt(max_x**2 + max_y**2))
+                # magnitude cannot be negative so 0 is the floor
+                return {"min": 0, "max": ceiling}
+
+            raise err
 
     def ensure_query_types(
         self,
@@ -179,21 +213,27 @@ class GetMap:
         :return:
         """
         # Data selection
-        self.parameter = query.layers
+        self.parameters = query.layers
         self.time_str = query.time
 
         if self.time_str:
             self.time = pd.to_datetime(self.time_str).tz_localize(None)
         else:
             self.time = None
-        self.has_time = self.TIME_CF_NAME in ds[self.parameter].cf.coords
+        self.has_time = all(
+            self.TIME_CF_NAME in ds[parameter].cf.coords
+            for parameter in self.parameters
+        )
 
         self.elevation_str = query.elevation
         if self.elevation_str:
             self.elevation = float(self.elevation_str)
         else:
             self.elevation = None
-        self.has_elevation = self.ELEVATION_CF_NAME in ds[self.parameter].cf.coords
+        self.has_elevation = all(
+            self.ELEVATION_CF_NAME in ds[parameter].cf.coords
+            for parameter in self.parameters
+        )
 
         # Grid
         self.crs = query.crs
@@ -209,7 +249,14 @@ class GetMap:
         # Output style
         self.decode_query_styles(query)
 
-        available_selectors = ds.gridded.additional_coords(ds[self.parameter])
+        available_selectors = list(
+            set.intersection(
+                *(
+                    set(ds.gridded.additional_coords(ds[parameter]))
+                    for parameter in self.parameters
+                ),
+            ),
+        )
         self.dim_selectors = {
             k: query_params[k] if k in query_params else None
             for k in available_selectors
@@ -219,27 +266,42 @@ class GetMap:
         """
         Decode request parameters related to render style
         """
-        _, raster_style = query.styles
-        # TODO: add more style options
-        self.style = "colormap"
+        style_type, colormap = query.styles
 
-        self.palettename = raster_style
-        # Let user pick cm from here https://predictablynoisy.com/matplotlib/gallery/color/colormap_reference.html#sphx-glr-gallery-color-colormap-reference-py
-        # Otherwise default to rainbow
-        if self.palettename == "default":
-            self.palettename = self.DEFAULT_PALETTE
+        # Let user pick colormap from here https://predictablynoisy.com/matplotlib/gallery/color/colormap_reference.html#sphx-glr-gallery-color-colormap-reference-py
+        # Otherwise default
+        palette_name = (
+            self.DEFAULT_PALETTE if colormap in ["colormap", "default"] else colormap
+        )
 
-        self.colorscalerange = query.colorscalerange
-        self.autoscale = query.autoscale
+        if style_type.startswith("vector"):
+            self.styles = VectorStyleParams(
+                type="vector",
+                color=query.color,
+                density=query.density or 2,
+                scaling=VectorStyleParams.GlyphScaling.CONSTANT,
+                colorscale_range=query.colorscalerange,
+                colormap=None if palette_name == "none" else palette_name,
+                draw_backing=palette_name != "none" and style_type == "vector-arrow",
+                arrow_mag_color=style_type == "vector-arrow-color",
+            )
+            return
 
+        # else: `style_type` is "raster"
+        self.styles = ColormapStyleParams(
+            type="colormap",
+            palettename=palette_name,
+            colorscale_range=query.colorscalerange,
+            autoscale=query.autoscale,
+        )
 
-    def select_layer(self, ds: xr.Dataset) -> xr.DataArray:
+    def select_layers(self, ds: xr.Dataset) -> list[xr.DataArray]:
         """
-        Select Dataset variable, according to WMS layers request
+        Select Dataset variables, according to WMS layers request
         :param ds:
         :return:
         """
-        return ds[self.parameter]
+        return [ds[parameter] for parameter in self.parameters]
 
     def select_time(self, da: xr.DataArray) -> xr.DataArray:
         """
@@ -334,12 +396,15 @@ class GetMap:
     def render(
         self,
         ds: xr.Dataset,
-        da: xr.DataArray,
-        buffer: io.BytesIO,
+        das: Iterable[xr.DataArray],
+        buffer: io.BytesIO | None,
         minmax_only: bool,
-    ) -> Union[bool, dict]:
+    ) -> Union[bool, List[xr.DataArray]]:
         """
-        Render the data array into an image buffer
+        Render the data array into an image buffer.
+
+        If `minmax_only` is True, return the DataArrays before rendering them into
+        the image buffer instead.
         """
 
         # default context object to pass around between grid functions
@@ -347,7 +412,8 @@ class GetMap:
         # and then send those values/flags to the next gridded function involved in the render process.
         #
         # ex. if ds.gridded.filter_by_bbox applies the grid mask to da, ds.gridded.project can avoid re-masking by checking the context
-        render_context = dict()
+        render_contexts = [dict() for _ in das]
+        das_with_contexts = list(zip(das, render_contexts))
 
         filter_start = time.time()
         filter_success = False
@@ -371,12 +437,15 @@ class GetMap:
             # Filter the data to only include the data within the bbox + buffer so
             # we don't have to render a ton of empty space or pull down more chunks
             # than we need
-            da, render_context = ds.gridded.filter_by_bbox(
-                da,
-                bbox,
-                self.crs,
-                render_context=render_context,
-            )
+            das_with_contexts = [
+                ds.gridded.filter_by_bbox(
+                    da,
+                    bbox,
+                    self.crs,
+                    render_context=context,
+                )
+                for da, context in das_with_contexts
+            ]
 
             filter_success = True
         except Exception as e:
@@ -389,80 +458,82 @@ class GetMap:
         # if filter_by_bbox was successful, preload data for projection
         if filter_success:
             filter_load_time = time.time()
-            da = da.load()
+            das_with_contexts = [
+                (da.load(), context) for da, context in das_with_contexts
+            ]
             logger.debug(
                 f"WMS GetMap load filtered data: {time.time() - filter_load_time}",
             )
 
         projection_start = time.time()
         try:
-            da, render_context = ds.gridded.project(
-                da,
-                self.crs,
-                render_context=render_context,
-            )
+            das_with_contexts = [
+                ds.gridded.project(
+                    da,
+                    self.crs,
+                    render_context=context,
+                )
+                for da, context in das_with_contexts
+            ]
         except Exception as e:
             logger.warning(f"Projection failed: {e}")
             if minmax_only:
                 logger.warning("Falling back to default minmax")
-                return {"min": float(da.min()), "max": float(da.max())}
+                return [da for da, _ in das_with_contexts]
+
+        das = [da for da, _ in das_with_contexts]
+        render_contexts = [context for _, context in das_with_contexts]
 
         # Squeeze single value dimensions
-        da = da.squeeze()
+        das = [da.squeeze() for da in das]
         logger.debug(f"WMS GetMap Projection time: {time.time() - projection_start}")
 
-        # Print the size of the da in megabytes
-        da_size = da.nbytes
-        if da_size > self.array_render_threshold_bytes:
+        # Print the size of the das in megabytes
+        das_size = sum(da.nbytes for da in das)
+        if das_size > self.array_render_threshold_bytes:
             logger.error(
-                f"DataArray size is {da_size:.2f} bytes, which is larger than the "
+                f"DataArrays size is {das_size:.2f} bytes, which is larger than the "
                 f"threshold of {self.array_render_threshold_bytes} bytes. "
                 f"Consider increasing the threshold in the plugin configuration.",
             )
             raise HTTPException(
                 413,
-                f"DataArray too large to render: threshold is {self.array_render_threshold_bytes} bytes, data is {da_size:.2f} bytes",
+                f"DataArrays too large to render: threshold is {self.array_render_threshold_bytes} bytes, data is {das_size:.2f} bytes",
             )
-        logger.debug(f"WMS GetMap loading DataArray size: {da_size:.2f} bytes")
+        logger.debug(f"WMS GetMap loading DataArray size: {das_size:.2f} bytes")
 
         start_dask = time.time()
-        da = da.load()
-        logger.debug(f"WMS GetMap load full data: {time.time() - start_dask}")
+        das = [da.load() for da in das]
+        logger.debug(f"wms getmap load full data: {time.time() - start_dask}")
 
-        if da.size == 0:
-            logger.warning("No data to render")
+        if sum(da.size for da in das) == 0:
+            logger.warning("no data to render")
             return False
 
         if minmax_only:
-            try:
-                return {
-                    "min": float(np.nanmin(da)),
-                    "max": float(np.nanmax(da)),
-                }
-            except Exception as e:
-                logger.error(
-                    f"Error computing minmax: {e}, falling back to full layer minmax",
-                )
-                return {"min": float(da.min()), "max": float(da.max())}
+            return das
 
         start_mesh = time.time()
-        mesh = self.create_mesh(ds, da, render_context=render_context)
+        meshes = [
+            self.create_mesh(ds, da, render_context=context)
+            for da, context in zip(das, render_contexts)
+        ]
         logger.debug(f"WMS GetMap Mesh time: {time.time() - start_mesh}")
 
         start_shade = time.time()
-        shaded = self.shade_mesh(mesh, )
+        im = self.shade_mesh(meshes)
         logger.debug(f"WMS GetMap Shade time: {time.time() - start_shade}")
 
-        im = shaded.to_pil()
+        assert buffer is not None, "buffer was None but minmax is False"
         im.save(buffer, format="PNG")
         return True
-    
+
     def create_mesh(
         self,
         ds: xr.Dataset,
         da: xr.DataArray,
         render_context: dict,
-    ) -> xr.Dataset:
+    ) -> xr.DataArray:
         """
         Create map mesh
         """
@@ -537,20 +608,42 @@ class GetMap:
                 tris,
             )
 
-        raise ValueError(f"Unexpected gridded dataset render method {ds.gridded.render_method}")
-    
-    def shade_mesh(self, mesh: xr.Dataset):
-        if self.style == "colormap":
-            span = (
-                None
-                if self.autoscale or self.colorscalerange is None
-                else tuple(self.colorscalerange[0:2])
+        raise ValueError(
+            f"Unexpected gridded dataset render method {ds.gridded.render_method}",
+        )
+
+    def shade_mesh(self, meshes: Sequence[xr.DataArray]) -> Image:
+        if self.styles.type == "vector":
+            style_kwargs = self.styles.model_dump()
+            style_kwargs.pop("type")
+            return visualize_vectors(
+                meshes,
+                **style_kwargs,
             )
-            return tf.shade(
-                mesh,
-                cmap=matplotlib.colormaps.get_cmap(self.palettename),
-                how="linear",
-                span=span,
-            )
-        # TODO other styles
-        raise NotImplementedError(f"{self.style} is not implemented yet")
+
+        # else -> self.style_params.type is "colormap"
+        span = (
+            None
+            if self.styles.autoscale or self.styles.colorscale_range is None
+            else tuple(self.styles.colorscale_range[0:2])
+        )
+        return tf.shade(
+            meshes[0],
+            cmap=matplotlib.colormaps.get_cmap(self.styles.palettename),
+            how="linear",
+            span=span,
+        ).to_pil()
+
+
+def das_to_scalar(das: List[xr.DataArray]) -> xr.DataArray | np.ndarray:
+    """Get a scalar data array from one or two data arrays.
+
+    We assume that the input `das` is length one or at least two.
+
+    If length is one, we simply return that single array. If length is more,
+    we assume there are two arrays and they are a pair of vector components.
+    In that case we return the vector magnitude.
+    """
+    if len(das) == 1:
+        return das[0]
+    return np.sqrt(das[0] ** 2 + das[1] ** 2)

--- a/xpublish_wms/wms/get_map/style_types.py
+++ b/xpublish_wms/wms/get_map/style_types.py
@@ -1,0 +1,36 @@
+"""Class definitions for GetMap rendering style information."""
+
+from enum import StrEnum
+from typing import Literal, Sequence
+
+from pydantic import BaseModel
+
+
+class ColormapStyleParams(BaseModel):
+    """Container for colormap style parameters."""
+
+    type: Literal["colormap"]
+    palettename: str
+    colorscale_range: Sequence[float] | None
+    autoscale: bool
+
+
+class VectorStyleParams(BaseModel):
+    """Container for vector style parameters."""
+
+    class GlyphScaling(StrEnum):
+        CONSTANT = "constant"
+        UNIFORM = "uniform"
+        # future option could be length/tail
+
+    type: Literal["vector"]
+    color: str
+    density: int
+    scaling: GlyphScaling
+    colorscale_range: tuple[float, float] | None
+    colormap: str | None
+    draw_backing: bool
+    arrow_mag_color: bool
+
+
+ShadingStyleParams = ColormapStyleParams | VectorStyleParams

--- a/xpublish_wms/wms/get_map/vector_style_utils.py
+++ b/xpublish_wms/wms/get_map/vector_style_utils.py
@@ -1,0 +1,88 @@
+"""Vector rendering helpers."""
+
+from typing import Any, MutableMapping, Tuple
+
+import matplotlib
+import numpy as np
+import xarray as xr
+from PIL.Image import Image, fromarray
+
+matplotlib.use("Agg")
+
+from matplotlib import pyplot as plt  # noqa: E402
+
+
+def get_meshgrid(
+    density: int,
+    tile_width: int,
+    tile_height: int,
+) -> tuple[np.ndarray[Tuple[int]], np.ndarray[Tuple[int]]]:
+    """Generate indices and a meshgrid for rendering vector glyphs."""
+    # For a 256x256 tile, there will be:
+    # - 4x4 glyphs at density 1,
+    # - 8x8 glyphs for density 2,
+    # - 16x16 glyphs for density 3.
+    grid_step = 64 // (2 ** (density - 1))
+    x_indices = np.arange(grid_step // 2, tile_width, grid_step)
+    y_indices = np.arange(grid_step // 2, tile_height, grid_step)
+    return x_indices, y_indices
+
+
+def setup_tile_plot(tile_width: int, tile_height: int) -> tuple[plt.Figure, plt.Axes]:
+    """Setup a plot with appropriate axes for rendering a tile."""
+    # Make a figure without a frame or axes, this ensures the image has the desired
+    # dimensions, as well as not drawing any axes.
+    fig = plt.figure(frameon=False, dpi=1, figsize=(tile_width, tile_height))
+    ax = plt.Axes(fig, [0, 0, 1, 1])
+    ax.set_axis_off()
+    # This is extremely important. It ensures that the frame of the figure used has the same
+    # dimensions and orientation as the raster tile
+    ax.set_xlim(0, tile_width)
+    ax.set_ylim(0, tile_height)
+    fig.add_axes(ax)
+
+    return fig, ax
+
+
+VectorArrowsRenderArgs = (
+    Tuple[np.ndarray[Tuple[int]], np.ndarray[Tuple[int]], xr.DataArray, xr.DataArray]
+    | Tuple[
+        np.ndarray[Tuple[int]],
+        np.ndarray[Tuple[int]],
+        xr.DataArray,
+        xr.DataArray,
+        xr.DataArray,
+    ]
+)
+
+
+def render_vector_arrows(
+    fig: plt.Figure,
+    ax: plt.Axes,
+    render_args: VectorArrowsRenderArgs,
+    render_kwargs: MutableMapping[str, Any],
+) -> Image:
+    """Plot vector arrows using `matplotlib.quiver` and create an `Image`.
+
+    Also call `matplotlib.close` at the end.
+    """
+    vmin = render_kwargs.pop("vmin")
+    vmax = render_kwargs.pop("vmax")
+    # Internally matplotlib scales the arrow width and length based on the number of arrows that
+    # render, and scale. We explicitly set the width to prevent arrows from being larger on
+    # tiles with fewer arrows, and we set scale=1 and units='xy' so we can very carefully set
+    # the arrow lengths.
+    mapped_render_args = (
+        *np.meshgrid(*render_args[:2]),
+        *render_args[2:4],
+        *render_args[4:5],
+    )
+    q = ax.quiver(*mapped_render_args, scale=1, units="xy", **render_kwargs)
+    if vmin is not None and vmax is not None:
+        q.set_clim(vmin, vmax)
+
+    fig.canvas.draw()
+    # Copy the matplotlib figure to an Image object
+    im = fromarray(np.asarray(fig.canvas.buffer_rgba()))
+    plt.close(fig)
+    return im

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -1,0 +1,100 @@
+"""Visualize vector direction."""
+
+from typing import Sequence
+
+import matplotlib
+import numpy as np
+import xarray as xr
+from PIL.Image import Image
+
+from xpublish_wms.wms.get_map.style_types import VectorStyleParams
+from xpublish_wms.wms.get_map.vector_style_utils import (
+    get_meshgrid,
+    render_vector_arrows,
+    setup_tile_plot,
+)
+
+# Scale arrow length
+LENGTH_SCALE = np.array([3, 2, 1]) * 9
+# Other arrow size parameters are relative to the tail width
+TAIL_WIDTH = np.array([3.5, 2, 1]) * 1.3
+HEAD_WIDTH = [2.5, 2.5, 3.5]
+# Arrow outline stroke width
+LINE_WIDTH = [5, 4, 1]
+
+
+def visualize_vectors(
+    meshes: Sequence[xr.DataArray],
+    color: str,
+    density: int,
+    scaling: VectorStyleParams.GlyphScaling,
+    colorscale_range: tuple[float, float] | None = None,
+    colormap: str | None = None,
+    draw_backing: bool = False,
+    arrow_mag_color: bool = False,
+) -> Image:
+    """Renders a vector tile image."""
+    # Create a mesh of grid-points where we will draw arrows/barbs
+    if density not in (1, 2, 3):
+        raise ValueError(f"Invalid density value {density}")
+
+    assert meshes[0].shape == meshes[1].shape
+    tile_height, tile_width = meshes[0].shape
+
+    x_indices, y_indices = get_meshgrid(density, tile_width, tile_height)
+
+    # Select the vector components in a subgrid
+    u = meshes[0].isel(x=x_indices, y=y_indices).astype(np.float32)
+    v = meshes[1].isel(x=x_indices, y=y_indices).astype(np.float32)
+    # use the entire mesh for magnitude not just the sparse u,v
+    mag: xr.DataArray = np.sqrt(
+        meshes[0] ** 2 + meshes[1] ** 2,
+    )  # pyright: ignore[reportAssignmentType]
+    # Initialize a plot with appropriate axes
+    fig, ax = setup_tile_plot(tile_width, tile_height)
+
+    # If colormap background is desired, draw it now
+    if draw_backing and colormap is not None:
+        ax.imshow(
+            mag,
+            cmap=colormap,
+            vmin=colorscale_range and colorscale_range[0],
+            vmax=colorscale_range and colorscale_range[1],
+            extent=(0, tile_width, 0, tile_height),
+            origin="lower",
+            interpolation="nearest",
+        )
+
+    # Scale the length up based on density
+    u *= LENGTH_SCALE[density - 1]
+    v *= LENGTH_SCALE[density - 1]
+    if scaling == VectorStyleParams.GlyphScaling.CONSTANT:
+        # normalize the vectors so their size is CONSTANT
+        u /= mag.isel(x=x_indices, y=y_indices)
+        v /= mag.isel(x=x_indices, y=y_indices)
+    else:
+        # scale up just a little
+        # TODO: this should depend on dataset and its max magnitude
+        u *= 3
+        v *= 3
+
+    render_args = (x_indices, y_indices, u, v)
+    if arrow_mag_color:
+        render_args += (mag.isel(x=x_indices, y=y_indices),)
+
+    # Sum the R, G, B values and determine a contrasting edgeline
+    edgecolor = "black" if sum(matplotlib.colors.to_rgb(color)) > 1.5 else "white"
+    render_kwargs = {
+        "color": color,
+        "edgecolor": edgecolor,
+        "linewidth": LINE_WIDTH[density - 1],
+        "linestyle": "solid",
+        "width": TAIL_WIDTH[density - 1],
+        "headwidth": HEAD_WIDTH[density - 1],
+        "headlength": 3,
+        "headaxislength": 2.8,
+        "cmap": colormap if arrow_mag_color else None,
+        "vmin": colorscale_range[0] if arrow_mag_color and colorscale_range else None,
+        "vmax": colorscale_range[1] if arrow_mag_color and colorscale_range else None,
+    }
+    return render_vector_arrows(fig, ax, render_args, render_kwargs)

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from typing import List
 
 import cachey
 import cf_xarray  # noqa
@@ -7,7 +8,11 @@ from fastapi import HTTPException, Response
 from fastapi.responses import JSONResponse
 
 from xpublish_wms.logger import logger
-from xpublish_wms.query import WMSGetMapQuery, WMSGetMetadataQuery
+from xpublish_wms.query import (
+    GET_MAP_STYLE_METHODS,
+    WMSGetMapQuery,
+    WMSGetMetadataQuery,
+)
 from xpublish_wms.utils import format_timestamp
 
 from .get_map import GetMap
@@ -25,29 +30,33 @@ def get_metadata(
 
     This is compliant subset of ncwms2's GetMetadata handler. Specifically, layerdetails, timesteps and minmax are supported.
     """
-    layer_name = query.layername
     metadata_type = query.item.lower()
 
-    if not layer_name and metadata_type != "minmax" and metadata_type != "menu":
+    if metadata_type in ["minmax", "menu"]:
+        pass  # minmax and menu do not require extra layers validation here
+    elif not query.layers:
         logger.error("layerName must be specified for GetMetadata requests")
         raise HTTPException(
             422,
             detail="layerName must be specified",
         )
-    elif layer_name not in ds and metadata_type != "minmax" and metadata_type != "menu":
-        logger.error(f"layerName {layer_name} not found in dataset")
+    elif any(layer not in ds for layer in query.layers):
+        not_found = [layer for layer in query.layers if layer not in ds]
+        logger.error(f"layers {not_found} were not found in dataset")
         raise HTTPException(
             422,
-            detail=f"layerName {layer_name} not found in dataset",
+            detail=f"layer name(s) {', '.join(not_found)} not found in dataset",
         )
 
     if metadata_type == "menu":
         payload = get_menu(ds)
     elif metadata_type == "layerdetails":
-        payload = get_layer_details(ds, layer_name)
+        payload = get_layer_details(ds, query.layers)
     elif metadata_type == "timesteps":
-        da = ds[layer_name]
-        payload = get_timesteps(da, query)
+        # If there are multiple layers, we assume they are vector components,
+        # and therefore should have the same timesteps, so we use the first layer name
+        first_layer = query.layers[0]
+        payload = get_timesteps(ds[first_layer], query)
     elif metadata_type == "minmax":
         payload = get_minmax(
             ds,
@@ -114,14 +123,14 @@ def get_minmax(
         service=query.service,
         version=query.version,
         request="GetMap",
-        layers=query.layername,
+        layers=query.layers and ",".join(query.layers),
         bbox=query.bbox if not entire_layer else "-180,-90,180,90",
         width=1 if entire_layer else 512,
         height=1 if entire_layer else 512,
         crs=query.crs,
         time=query.time,
         elevation=query.elevation,
-        styles="raster/default",
+        styles="raster/default" if len(query.layers or []) == 1 else "vector/none",
         colorscalerange="nan,nan",
     )
 
@@ -132,42 +141,58 @@ def get_minmax(
     return getmap.get_minmax(ds, getmap_query, query_params, entire_layer)
 
 
-def get_layer_details(ds: xr.Dataset, layer_name: str) -> dict:
+def get_layer_details(ds: xr.Dataset, layers: List[str]) -> dict:
     """
-    Returns a subset of layer details for the requested layer
+    Returns a subset of layer details for the requested layers
     """
-    da = ds[layer_name]
-    units = da.attrs.get("units", "")
-    supported_styles = "raster"  # TODO: more styles
-    bbox = ds.gridded.bbox(da)
-    if ds.gridded.has_elevation(da):
-        elevation = ds.gridded.elevations(da).values.round(5).tolist()
-        elevation_positive = ds.gridded.elevation_positive_direction(da)
-        elevation_units = ds.gridded.elevation_units(da)
+    das = [ds[layer] for layer in layers]
+
+    # We mostly just assume that multiple layers are vector components and that
+    # the client knows what they're doing but here we do a simple validation for it
+    all_units = {da.attrs.get("units", "") for da in das}
+    if len(all_units) > 1:
+        raise HTTPException(422, "Selected layers have different units")
+    units = next(iter(all_units))
+
+    supported_styles = [
+        s
+        for s in GET_MAP_STYLE_METHODS
+        if s.startswith("raster" if len(das) == 1 else "vector")
+    ]
+
+    # Otherwise take metadata from the first layer and assume second is the same
+    da1 = das[0]
+    bbox = ds.gridded.bbox(da1)
+    if ds.gridded.has_elevation(da1):
+        elevation = ds.gridded.elevations(da1).values.round(5).tolist()
+        elevation_positive = ds.gridded.elevation_positive_direction(da1)
+        elevation_units = ds.gridded.elevation_units(da1)
     else:
         elevation = None
         elevation_positive = None
         elevation_units = None
-    if "time" in da.cf:
-        timesteps = format_timestamp(da.cf["time"]).tolist()
+    if "time" in da1.cf:
+        timesteps = format_timestamp(da1.cf["time"]).tolist()
     else:
         timesteps = None
 
-    additional_coords = ds.gridded.additional_coords(da)
+    additional_coords = ds.gridded.additional_coords(da1)
     additional_coord_values = {
         coord: (
-            da.cf.coords[coord] if coord in da.cf.coords else da[coord]
+            da1.cf.coords[coord] if coord in da1.cf.coords else da1[coord]
         ).values.tolist()
         for coord in additional_coords
     }
 
     return {
-        "layerName": da.name,
-        "standard_name": da.cf.attrs.get("standard_name", da.name),
-        "long_name": da.cf.attrs.get("long_name", da.name),
+        "layerName": ",".join(str(da.name) for da in das),
+        "standard_name": ",".join(
+            da.cf.attrs.get("standard_name", da.name) for da in das
+        ),
+        "long_name": ",".join(da.cf.attrs.get("long_name", da.name) for da in das),
         "bbox": bbox,
         "units": units,
-        "supportedStyles": [supported_styles],
+        "supportedStyles": supported_styles,
         "elevation": elevation,
         "elevation_positive": elevation_positive,
         "elevation_units": elevation_units,


### PR DESCRIPTION
#### Preface:
1. I am aware that this is a quite a large diff, so please let me know if you'd like me to try and split the commits into multiple PRs somehow.
2. Lot of decisions were made here - not just in the implementation but in the design of the new API parts - so feel free to start a discussion if something seems wrong to you. (new parameters, their names and expected values, delimiters, etc.)

### What
- Add support for rendering two layers as a vector tile in two different styles.
  - This change is mostly contained in the largest commit 98b4e503392143507d6398e556d398c85b2a367d.
- Add support for vector tile metadata queries.
- Amount of refactoring included. Some of it is just moving code around, some is simplifying it, all to make the support of vector tiles easier and maintainable.
 
### How/Why
- aims to solve #146, more vector styles could be added in the future (including a grayscale direction raster)
- assuming I haven't introduced any bugs, preexisting single layer functionality should remain unchanged
- rendering of multiple layers is implemented by wrapping every rendering step in a list comprehension, doing given step for every individual layer
  - this introduces a little extra overhead for single raster layers, but I haven't seen an obvious increase in render time
- generally, throughout the changes we assume that multiple layers mean two vector components
- I tried to keep commit messages informative, so more details are available per commit

We have an [xreds](https://github.com/asascience-open/xreds) instance deployed using the `xpublish-wms` fork with these changes that I might be able to share later.

Example NGOFS2 using `vector-arrow/default` style:
<img width="652" height="671" alt="image" src="https://github.com/user-attachments/assets/24e91ee0-331a-463d-95a9-30ec0207636c" />

____
cc: @srstsavage