### PR TITLE
Fix vectors minmax and scalar elevation variable handling

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,7 +18,6 @@ pre-commit
 pylint
 pytest
 pytest-cov
-pytest-flake8
 pytest-xdist
 scipy
 setuptools_scm

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ flake8-builtins
 flake8-comprehensions
 flake8-mutable
 flake8-print
-httpx
+httpx2
 interrogate
 isort
 myst-parser

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -122,7 +122,10 @@ def test_get_feature_info(xpublish_client):
     ), "Response is not json"
 
     data = response.json()
-    assert data["ranges"]["air"]["values"] == [287.005456059975]
+    assert data["ranges"]["air"]["values"] == pytest.approx(
+        [287.005456059975],
+        abs=1e-13,
+    )
 
     response = xpublish_client.get(
         "datasets/air/wms?version=1.3.0&service=WMS&request=GetFeatureInfo&crs=EPSG:4326&bbox=-100.0,30.0,-101.0,31.0&width=50&height=50&query_layers=air&x=25&y=25&time=2013-01-01T00:00:00/2013-01-02T00:00:00",
@@ -141,13 +144,16 @@ def test_get_feature_info(xpublish_client):
         "2013-01-01T18:00:00Z",
         "2013-01-02T00:00:00Z",
     ]
-    assert data["ranges"]["air"]["values"] == [
-        287.005456059975,
-        281.3892503123699,
-        278.29012911286964,
-        279.74098292378176,
-        282.26759683465224,
-    ]
+    assert data["ranges"]["air"]["values"] == pytest.approx(
+        [
+            287.005456059975,
+            281.3892503123699,
+            278.29012911286964,
+            279.74098292378176,
+            282.26759683465224,
+        ],
+        abs=1e-13,
+    )
 
 
 def test_get_legend_graphic(xpublish_client):

--- a/xpublish_wms/grids/fvcom.py
+++ b/xpublish_wms/grids/fvcom.py
@@ -67,23 +67,22 @@ class FVCOMGrid(Grid):
     def elevations(self, da: xr.DataArray) -> Optional[xr.DataArray]:
         if "vertical" in da.cf:
             return da.cf["vertical"][:, 0]
+
+        # Sometimes fvcom variables dont have coordinates assigned correctly, so brute force it
+        vertical_var = None
+        if "siglay" in da.dims:
+            vertical_var = "siglay"
+        elif "siglev" in da.dims:
+            vertical_var = "siglev"
         else:
-            # Sometimes fvcom variables dont have coordinates assigned correctly, so brute force it
-            vertical_var = None
-            if "siglay" in da.dims:
-                vertical_var = "siglay"
-            elif "siglev" in da.dims:
-                vertical_var = "siglev"
+            return None
 
-            if vertical_var is not None:
-                return xr.DataArray(
-                    data=self.ds[vertical_var][:, 0].values,
-                    dims=vertical_var,
-                    name=self.ds[vertical_var].name,
-                    attrs=self.ds[vertical_var].attrs,
-                )
-
-        return None
+        return xr.DataArray(
+            data=self.ds[vertical_var][:, 0].values,
+            dims=vertical_var,
+            name=self.ds[vertical_var].name,
+            attrs=self.ds[vertical_var].attrs,
+        )
 
     def sel_lat_lng(
         self,

--- a/xpublish_wms/grids/grid.py
+++ b/xpublish_wms/grids/grid.py
@@ -73,7 +73,12 @@ class Grid(ABC):
     def elevations(self, da: xr.DataArray) -> Optional[xr.DataArray]:
         """Return the elevations for the given data array"""
         if "vertical" in da.cf:
-            return da.cf["vertical"]
+            vertical = da.cf["vertical"]
+            if vertical.ndim > 0:
+                return vertical
+            # Promote scalar coordinate to 1-D so callers can safely iterate/index
+            dim_name = vertical.name or "vertical"
+            return vertical.expand_dims(dim_name)
         else:
             return None
 
@@ -92,12 +97,13 @@ class Grid(ABC):
             elevations = [0.0]
 
         if "vertical" in da.cf:
+            if da.cf["vertical"].ndim == 0:
+                return da
             if len(elevations) == 1:
                 return da.cf.sel(vertical=elevations[0], method="nearest")
-            elif len(elevations) > 1:
+            if len(elevations) > 1:
                 return da.cf.sel(vertical=elevations)
-            else:
-                return da.cf.sel(vertical=0, method="nearest")
+            return da.cf.sel(vertical=0, method="nearest")
 
         return da
 

--- a/xpublish_wms/grids/triangular.py
+++ b/xpublish_wms/grids/triangular.py
@@ -133,7 +133,7 @@ class TriangularGrid(Grid):
         elevations: Optional[Sequence[float]],
     ) -> xr.DataArray:
         """Select the given data array by elevation"""
-        if not self.has_elevation(da):
+        if not self.has_elevation(da) or "vertical" not in da.cf:
             return da
 
         if (
@@ -151,10 +151,8 @@ class TriangularGrid(Grid):
         ]
         if len(elevation_index) == 1:
             elevation_index = elevation_index[0]
-        if "vertical" in da.cf:
-            da = da.cf.isel(vertical=elevation_index)
 
-        return da
+        return da.cf.isel(vertical=elevation_index)
 
     def additional_coords(self, da):
         filter_dims = ["nele", "node", "mesh", "nvertex", "nbou", "nope", "nvel_dim"]

--- a/xpublish_wms/grids/triangular.py
+++ b/xpublish_wms/grids/triangular.py
@@ -151,7 +151,6 @@ class TriangularGrid(Grid):
         ]
         if len(elevation_index) == 1:
             elevation_index = elevation_index[0]
-
         if "vertical" in da.cf:
             da = da.cf.isel(vertical=elevation_index)
 

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -524,7 +524,9 @@ class GetMap:
         im = self.shade_mesh(meshes)
         logger.debug(f"WMS GetMap Shade time: {time.time() - start_shade}")
 
-        assert buffer is not None, "buffer was None but minmax is False"
+        # NOTE: remember `assert` can be disabled with `python -O`
+        # This should never fail, caller should always pass `buffer` unless `minax=True`
+        assert buffer is not None
         im.save(buffer, format="PNG")
         return True
 

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -38,6 +38,8 @@ def visualize_vectors(
     if density not in (1, 2, 3):
         raise ValueError(f"Invalid density value {density}")
 
+    # NOTE: remember `assert` can be disabled with `python -O`
+    # This should never fail, datashader renders both in the shape of the tile
     assert meshes[0].shape == meshes[1].shape
     tile_height, tile_width = meshes[0].shape
 

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -118,19 +118,22 @@ def get_minmax(
 
     If BBOX is not specified, the entire selected temporal and elevation range is used.
     """
+    # validation should ensure that layers is not `None`
+    assert query.layers, "get_minmax expects query to have layers"
+
     entire_layer = query.bbox is None
     getmap_query = WMSGetMapQuery(
         service=query.service,
         version=query.version,
         request="GetMap",
-        layers=query.layers and ",".join(query.layers),
+        layers=",".join(query.layers),
         bbox=query.bbox if not entire_layer else "-180,-90,180,90",
         width=1 if entire_layer else 512,
         height=1 if entire_layer else 512,
         crs=query.crs,
         time=query.time,
         elevation=query.elevation,
-        styles="raster/default" if len(query.layers or []) == 1 else "vector/none",
+        styles="raster/default" if len(query.layers) == 1 else "vector-arrow/none",
         colorscalerange="nan,nan",
     )
 

--- a/xpublish_wms/wms/get_metadata.py
+++ b/xpublish_wms/wms/get_metadata.py
@@ -118,8 +118,9 @@ def get_minmax(
 
     If BBOX is not specified, the entire selected temporal and elevation range is used.
     """
-    # validation should ensure that layers is not `None`
-    assert query.layers, "get_minmax expects query to have layers"
+    # NOTE: remember `assert` can be disabled with `python -O`
+    # This should never fail, validation ensures layers are not `None` for minmax
+    assert query.layers
 
     entire_layer = query.bbox is None
     getmap_query = WMSGetMapQuery(


### PR DESCRIPTION
- if elevation variable is scalar for a regular grid, promote it to 1D so that the elevations can reliably be a list
- also fix the internal GetMap query when getting minmax metadata for vector layers
- plus a small refactor of elevation related `if-else` blocks for fvcom and triangular grids