### PR TITLE
Add cell center aligned arrow rendering style

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -245,6 +245,8 @@ def test_get_map_vectors():
         "vector-arrow/none",
         "vector-arrow/default",
         "vector-arrow-color/default",
+        "vector-cells-arrow/default",
+        "vector-cells-arrow-color/default",
     ]:
         getmap_query = WMSGetMapQuery.model_validate(
             {

--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -158,11 +158,19 @@ class WMSGetMetadataQuery(WMSBaseQuery):
 # - vector-arrow-tail/none (magnitude visualized by arrow tail length),
 # - vector-arrow-scale/none (magnitude visualized by uniform arrow scaling),
 # - vector-barb/none
-GetMapStyleMethod = Literal["raster", "vector-arrow", "vector-arrow-color"]
+GetMapStyleMethod = Literal[
+    "raster",
+    "vector-arrow",
+    "vector-arrow-color",
+    "vector-cells-arrow",
+    "vector-cells-arrow-color",
+]
 GET_MAP_STYLE_METHODS: List[GetMapStyleMethod] = [
     "raster",
     "vector-arrow",
     "vector-arrow-color",
+    "vector-cells-arrow",
+    "vector-cells-arrow-color",
 ]
 
 
@@ -176,13 +184,17 @@ class WMSGetMapQuery(WMSBaseQuery):
     styles: tuple[GetMapStyleMethod, Literal["none"] | str] = Field(
         ("raster", "default"),
         description=(
-            "Style to use for the query. Options: 'raster/<colormap>', 'vector-arrow/none', "
-            "'vector-arrow/<colormap>', 'vector-arrow-color/<colormap>'. You can provide "
-            "a name of any colormap defined by matplotlib's defaults directly like 'raster/turbo'. "
-            "For vector tiles, 'vector-arrow/<colormap> renders directional arrows with "
-            "raster backing visualizing magnitude. 'vector-arrow/none' can be used for arrows only. "
-            "Passing 'raster/default' uses the default colormap. "
-            "This parameter defaults to 'raster/default'."
+            "Rendering style in the format '<method>/<palette>'. "
+            "Supported methods: 'raster', 'vector-arrow', 'vector-arrow-color', "
+            "'vector-cells-arrow', 'vector-cells-arrow-color'. "
+            "Examples: 'raster/default', 'raster/turbo', 'vector-arrow/none', "
+            "'vector-arrow/magma', 'vector-arrow-color/viridis', "
+            "'vector-cells-arrow/none', 'vector-cells-arrow-color/plasma'. "
+            "For vector methods, '/none' disables magnitude colormap coloring/backing when applicable. "
+            "'vector-arrow/<palette>' draws arrows over a magnitude-colored raster backing. "
+            "'vector-arrow-color/<palette>' colors arrow glyphs by magnitude. "
+            "'vector-cells-arrow*' variants place at most one arrow per source data cell. "
+            "The default is 'raster/default'."
         ),
     )
     crs: Literal["EPSG:4326", "EPSG:3857"] = Field(

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -521,7 +521,7 @@ class GetMap:
             for da, context in zip(das, render_contexts)
         ]
         cell_center_indices = (
-            get_cell_center_indices(das, self.bbox, self.width, self.height)
+            get_cell_center_indices(das, self.bbox, self.width, self.height, self.styles.density)
             if self.styles.type == "vector" and self.styles.use_cell_centers
             else None
         )

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -1,3 +1,4 @@
+import functools
 import io
 import time
 from datetime import datetime
@@ -11,11 +12,11 @@ import datashader.transfer_functions as tf
 import matplotlib
 import mercantile
 import numpy as np
-from numpy.typing import NDArray
 import pandas as pd
 import xarray as xr
 from fastapi import HTTPException
 from fastapi.responses import Response
+from numpy.typing import NDArray
 from PIL.Image import Image
 
 from xpublish_wms.grids import RenderMethod
@@ -26,7 +27,11 @@ from xpublish_wms.wms.get_map.style_types import (
     ShadingStyleParams,
     VectorStyleParams,
 )
-from xpublish_wms.wms.get_map.vector_styles import visualize_vectors, get_cell_center_indices
+from xpublish_wms.wms.get_map.vector_style_utils import get_grid_step
+from xpublish_wms.wms.get_map.vector_styles import (
+    get_cell_center_indices,
+    visualize_vectors,
+)
 
 
 class GetMap:
@@ -55,12 +60,46 @@ class GetMap:
 
     # Grid
     crs: str
-    bbox = List[float]
+    bbox: tuple[float, float, float, float]
     width: int
     height: int
 
     # Output style
     styles: ShadingStyleParams
+
+    # NOTE: none of the following cached properties should be accessed before
+    # `ensure_query_types` populates the static attributes above
+
+    @functools.cached_property
+    def margin_px(self) -> int:
+        """Pixel margin added to each side of the mesh canvas for cell-center vector styles."""
+        if self.styles.type == "vector" and self.styles.use_cell_centers:
+            return get_grid_step(self.styles.density)
+        return 0
+
+    @functools.cached_property
+    def mesh_bbox(self) -> tuple[float, float, float, float]:
+        """Tile bbox expanded by margin_px on each side, in data coordinates."""
+        if self.margin_px == 0:
+            return self.bbox
+        x_span = abs(self.bbox[2] - self.bbox[0])
+        y_span = abs(self.bbox[3] - self.bbox[1])
+        x_margin = x_span / self.width * self.margin_px
+        y_margin = y_span / self.height * self.margin_px
+        return (
+            self.bbox[0] - x_margin,
+            self.bbox[1] - y_margin,
+            self.bbox[2] + x_margin,
+            self.bbox[3] + y_margin,
+        )
+
+    @functools.cached_property
+    def mesh_width(self) -> int:
+        return self.width + 2 * self.margin_px
+
+    @functools.cached_property
+    def mesh_height(self) -> int:
+        return self.height + 2 * self.margin_px
 
     def __init__(
         self,
@@ -283,8 +322,10 @@ class GetMap:
                 scaling=VectorStyleParams.GlyphScaling.CONSTANT,
                 colorscale_range=query.colorscalerange,
                 colormap=None if palette_name == "none" else palette_name,
-                draw_backing=palette_name != "none" and style_type in ("vector-arrow", "vector-cells-arrow"),
-                arrow_mag_color=style_type in ("vector-arrow-color", "vector-cells-arrow-color"),
+                draw_backing=palette_name != "none"
+                and style_type in ("vector-arrow", "vector-cells-arrow"),
+                arrow_mag_color=style_type
+                in ("vector-arrow-color", "vector-cells-arrow-color"),
                 use_cell_centers=style_type.startswith("vector-cells-"),
             )
             return
@@ -420,14 +461,17 @@ class GetMap:
         filter_start = time.time()
         filter_success = False
         try:
-            # Grab a buffer around the bbox to ensure we have enough data to render
-            x_buffer = (
-                abs(max(self.bbox[0], self.bbox[2]) - min(self.bbox[0], self.bbox[2]))
-                * 0.15
+            # Grab a buffer around the bbox to ensure we have enough data to render.
+            # Use at least the margin fraction so margin-cell data is always fetched.
+            x_span = abs(self.bbox[2] - self.bbox[0])
+            y_span = abs(self.bbox[3] - self.bbox[1])
+            x_buffer = x_span * max(
+                0.15,
+                (self.margin_px / self.width) if self.width else 0,
             )
-            y_buffer = (
-                abs(max(self.bbox[1], self.bbox[3]) - min(self.bbox[1], self.bbox[3]))
-                * 0.15
+            y_buffer = y_span * max(
+                0.15,
+                (self.margin_px / self.height) if self.height else 0,
             )
             bbox = [
                 self.bbox[0] - x_buffer,
@@ -521,7 +565,13 @@ class GetMap:
             for da, context in zip(das, render_contexts)
         ]
         cell_center_indices = (
-            get_cell_center_indices(das, self.bbox, self.width, self.height, self.styles.density)
+            get_cell_center_indices(
+                das,
+                self.mesh_bbox,
+                self.mesh_width,
+                self.mesh_height,
+                self.styles.density,
+            )
             if self.styles.type == "vector" and self.styles.use_cell_centers
             else None
         )
@@ -569,10 +619,10 @@ class GetMap:
                 )
 
         cvs = dsh.Canvas(
-            plot_height=self.height,
-            plot_width=self.width,
-            x_range=(self.bbox[0], self.bbox[2]),
-            y_range=(self.bbox[1], self.bbox[3]),
+            plot_height=self.mesh_height,
+            plot_width=self.mesh_width,
+            x_range=(self.mesh_bbox[0], self.mesh_bbox[2]),
+            y_range=(self.mesh_bbox[1], self.mesh_bbox[3]),
         )
 
         if ds.gridded.render_method == RenderMethod.Raster:
@@ -633,6 +683,7 @@ class GetMap:
             return visualize_vectors(
                 meshes,
                 cell_center_indices=cell_center_indices if use_cell_centers else None,
+                margin_px=self.margin_px,
                 **style_kwargs,
             )
 

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -11,6 +11,7 @@ import datashader.transfer_functions as tf
 import matplotlib
 import mercantile
 import numpy as np
+from numpy.typing import NDArray
 import pandas as pd
 import xarray as xr
 from fastapi import HTTPException
@@ -25,7 +26,7 @@ from xpublish_wms.wms.get_map.style_types import (
     ShadingStyleParams,
     VectorStyleParams,
 )
-from xpublish_wms.wms.get_map.vector_styles import visualize_vectors
+from xpublish_wms.wms.get_map.vector_styles import visualize_vectors, get_cell_center_indices
 
 
 class GetMap:
@@ -282,8 +283,9 @@ class GetMap:
                 scaling=VectorStyleParams.GlyphScaling.CONSTANT,
                 colorscale_range=query.colorscalerange,
                 colormap=None if palette_name == "none" else palette_name,
-                draw_backing=palette_name != "none" and style_type == "vector-arrow",
-                arrow_mag_color=style_type == "vector-arrow-color",
+                draw_backing=palette_name != "none" and style_type in ("vector-arrow", "vector-cells-arrow"),
+                arrow_mag_color=style_type in ("vector-arrow-color", "vector-cells-arrow-color"),
+                use_cell_centers=style_type.startswith("vector-cells-"),
             )
             return
 
@@ -518,10 +520,15 @@ class GetMap:
             self.create_mesh(ds, da, render_context=context)
             for da, context in zip(das, render_contexts)
         ]
+        cell_center_indices = (
+            get_cell_center_indices(das, self.bbox, self.width, self.height)
+            if self.styles.type == "vector" and self.styles.use_cell_centers
+            else None
+        )
         logger.debug(f"WMS GetMap Mesh time: {time.time() - start_mesh}")
 
         start_shade = time.time()
-        im = self.shade_mesh(meshes)
+        im = self.shade_mesh(meshes, cell_center_indices)
         logger.debug(f"WMS GetMap Shade time: {time.time() - start_shade}")
 
         # NOTE: remember `assert` can be disabled with `python -O`
@@ -614,12 +621,18 @@ class GetMap:
             f"Unexpected gridded dataset render method {ds.gridded.render_method}",
         )
 
-    def shade_mesh(self, meshes: Sequence[xr.DataArray]) -> Image:
+    def shade_mesh(
+        self,
+        meshes: Sequence[xr.DataArray],
+        cell_center_indices: tuple[NDArray[np.intp], NDArray[np.intp]] | None,
+    ) -> Image:
         if self.styles.type == "vector":
             style_kwargs = self.styles.model_dump()
             style_kwargs.pop("type")
+            use_cell_centers = style_kwargs.pop("use_cell_centers")
             return visualize_vectors(
                 meshes,
+                cell_center_indices=cell_center_indices if use_cell_centers else None,
                 **style_kwargs,
             )
 

--- a/xpublish_wms/wms/get_map/style_types.py
+++ b/xpublish_wms/wms/get_map/style_types.py
@@ -31,6 +31,7 @@ class VectorStyleParams(BaseModel):
     colormap: str | None
     draw_backing: bool
     arrow_mag_color: bool
+    use_cell_centers: bool = False
 
 
 ShadingStyleParams = ColormapStyleParams | VectorStyleParams

--- a/xpublish_wms/wms/get_map/vector_style_utils.py
+++ b/xpublish_wms/wms/get_map/vector_style_utils.py
@@ -4,7 +4,7 @@ from typing import Any, MutableMapping, Tuple
 
 import matplotlib
 import numpy as np
-import xarray as xr
+from numpy.typing import NDArray
 from PIL.Image import Image, fromarray
 
 matplotlib.use("Agg")
@@ -12,20 +12,26 @@ matplotlib.use("Agg")
 from matplotlib import pyplot as plt  # noqa: E402
 
 
+def get_grid_step(density: int) -> int:
+    """Return vector glyph grid step for given density."""
+    return 64 // (2 ** (density - 1))
+
+
 def get_meshgrid(
     density: int,
     tile_width: int,
     tile_height: int,
-) -> tuple[np.ndarray[Tuple[int]], np.ndarray[Tuple[int]]]:
-    """Generate indices and a meshgrid for rendering vector glyphs."""
+) -> Tuple[NDArray[np.intp], NDArray[np.intp]]:
+    """Return flat (x, y) pixel index pairs for the vector subgrid."""
     # For a 256x256 tile, there will be:
     # - 4x4 glyphs at density 1,
     # - 8x8 glyphs for density 2,
     # - 16x16 glyphs for density 3.
-    grid_step = 64 // (2 ** (density - 1))
+    grid_step = get_grid_step(density)
     x_indices = np.arange(grid_step // 2, tile_width, grid_step)
     y_indices = np.arange(grid_step // 2, tile_height, grid_step)
-    return x_indices, y_indices
+    x_indices_grid, y_indices_grid = np.meshgrid(x_indices, y_indices)
+    return x_indices_grid.ravel(), y_indices_grid.ravel()
 
 
 def setup_tile_plot(tile_width: int, tile_height: int) -> tuple[plt.Figure, plt.Axes]:
@@ -45,13 +51,13 @@ def setup_tile_plot(tile_width: int, tile_height: int) -> tuple[plt.Figure, plt.
 
 
 VectorArrowsRenderArgs = (
-    Tuple[np.ndarray[Tuple[int]], np.ndarray[Tuple[int]], xr.DataArray, xr.DataArray]
+    Tuple[NDArray[np.intp], NDArray[np.intp], NDArray[np.float32], NDArray[np.float32]]
     | Tuple[
-        np.ndarray[Tuple[int]],
-        np.ndarray[Tuple[int]],
-        xr.DataArray,
-        xr.DataArray,
-        xr.DataArray,
+        NDArray[np.intp],
+        NDArray[np.intp],
+        NDArray[np.float32],
+        NDArray[np.float32],
+        NDArray[np.float32],
     ]
 )
 
@@ -72,12 +78,7 @@ def render_vector_arrows(
     # render, and scale. We explicitly set the width to prevent arrows from being larger on
     # tiles with fewer arrows, and we set scale=1 and units='xy' so we can very carefully set
     # the arrow lengths.
-    mapped_render_args = (
-        *np.meshgrid(*render_args[:2]),
-        *render_args[2:4],
-        *render_args[4:5],
-    )
-    q = ax.quiver(*mapped_render_args, scale=1, units="xy", **render_kwargs)
+    q = ax.quiver(*render_args, scale=1, units="xy", **render_kwargs)
     if vmin is not None and vmax is not None:
         q.set_clim(vmin, vmax)
 

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -10,6 +10,7 @@ from PIL.Image import Image
 
 from xpublish_wms.wms.get_map.style_types import VectorStyleParams
 from xpublish_wms.wms.get_map.vector_style_utils import (
+    get_grid_step,
     get_meshgrid,
     render_vector_arrows,
     setup_tile_plot,
@@ -31,16 +32,7 @@ def get_cell_center_indices(
     height: int,
     density: int,
 ) -> tuple[NDArray[np.intp], NDArray[np.intp]]:
-    """Return (x_indices, y_indices) pixel coordinates of data cell centers within the tile.
-
-    Uses broadcast_like to expand 1-D dimensional coords (regular grids) to the
-    data's dimension order before raveling, ensuring x/y positions correspond to
-    values element-wise. Both returned arrays are 1D and the same length.
-
-    Subsampling mirrors get_meshgrid: cell centers are binned into pixel-space
-    buckets of size `grid_step`; bucket centers are averaged so very dense
-    datasets do not draw too many arrows in a single tile.
-    """
+    """Return (px, py) pixel coordinates of subsampled data cell centers."""
     x_full = das[0].x.broadcast_like(das[0])
     y_full = das[0].y.broadcast_like(das[0])
     px = np.floor(
@@ -53,12 +45,17 @@ def get_cell_center_indices(
     in_tile = (px >= 0) & (px < width) & (py >= 0) & (py < height)
     px, py = px[in_tile], py[in_tile]
 
-    # Subsample data points to prevent too many vector glyphs
-    grid_step = 64 // (2 ** (density - 1))
-    bucket_ids = (px // grid_step) * (height // grid_step + 1) + (py // grid_step)
-    # all the buckets with more than one cell center
+    grid_step = get_grid_step(density)
+    x_span = bbox[2] - bbox[0]
+    y_span = bbox[3] - bbox[1]
+    # Use globally aligned buckets so neighboring tiles use the same subsampling phase.
+    px_shifted = px + int((bbox[0] / x_span * width) % grid_step)
+    py_shifted = py + int((bbox[1] / y_span * height) % grid_step)
+    bucket_ids = (px_shifted // grid_step) * (height // grid_step + 1) + (
+        py_shifted // grid_step
+    )
+
     _, inverse = np.unique(bucket_ids, return_inverse=True)
-    # calculate a mean point for multiple cell centers by averaging their coords
     counts = np.bincount(inverse)
     px_sub = (np.bincount(inverse, weights=px) / counts).round().astype(np.intp)
     py_sub = (np.bincount(inverse, weights=py) / counts).round().astype(np.intp)
@@ -76,6 +73,7 @@ def visualize_vectors(
     draw_backing: bool = False,
     arrow_mag_color: bool = False,
     cell_center_indices: tuple[NDArray[np.intp], NDArray[np.intp]] | None = None,
+    margin_px: int = 0,
 ) -> Image:
     """Renders a vector tile image."""
     if density not in (1, 2, 3):
@@ -108,9 +106,8 @@ def visualize_vectors(
         x_indices, y_indices = get_meshgrid(density, tile_width, tile_height)
     else:
         x_indices, y_indices = cell_center_indices
-        valid = (
-            np.isfinite(meshes[0].values[y_indices, x_indices])
-            & np.isfinite(meshes[1].values[y_indices, x_indices])
+        valid = np.isfinite(meshes[0].values[y_indices, x_indices]) & np.isfinite(
+            meshes[1].values[y_indices, x_indices],
         )
         x_indices, y_indices = x_indices[valid], y_indices[valid]
 
@@ -151,4 +148,9 @@ def visualize_vectors(
         "vmin": colorscale_range[0] if arrow_mag_color and colorscale_range else None,
         "vmax": colorscale_range[1] if arrow_mag_color and colorscale_range else None,
     }
-    return render_vector_arrows(fig, ax, render_args, render_kwargs)
+    im = render_vector_arrows(fig, ax, render_args, render_kwargs)
+    if margin_px > 0:
+        im = im.crop(
+            (margin_px, margin_px, im.width - margin_px, im.height - margin_px),
+        )
+    return im

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -5,6 +5,7 @@ from typing import Sequence
 import matplotlib
 import numpy as np
 import xarray as xr
+from numpy.typing import NDArray
 from PIL.Image import Image
 
 from xpublish_wms.wms.get_map.style_types import VectorStyleParams
@@ -23,6 +24,26 @@ HEAD_WIDTH = [2.5, 2.5, 3.5]
 LINE_WIDTH = [5, 4, 1]
 
 
+def get_cell_center_indices(
+    das: Sequence[xr.DataArray],
+    bbox: tuple[float, float, float, float],
+    width: int,
+    height: int,
+) -> tuple[NDArray[np.intp], NDArray[np.intp]]:
+    """Return (x_indices, y_indices) pixel coordinates of data cell centers."""
+    x_full = das[0].x.broadcast_like(das[0])
+    y_full = das[0].y.broadcast_like(das[0])
+    px = np.floor(
+        (x_full.values.ravel() - bbox[0]) / (bbox[2] - bbox[0]) * width,
+    ).astype(np.intp)
+    py = np.floor(
+        (y_full.values.ravel() - bbox[1]) / (bbox[3] - bbox[1]) * height,
+    ).astype(np.intp)
+
+    in_tile = (px >= 0) & (px < width) & (py >= 0) & (py < height)
+    return px[in_tile], py[in_tile]
+
+
 def visualize_vectors(
     meshes: Sequence[xr.DataArray],
     color: str,
@@ -32,9 +53,9 @@ def visualize_vectors(
     colormap: str | None = None,
     draw_backing: bool = False,
     arrow_mag_color: bool = False,
+    cell_center_indices: tuple[NDArray[np.intp], NDArray[np.intp]] | None = None,
 ) -> Image:
     """Renders a vector tile image."""
-    # Create a mesh of grid-points where we will draw arrows/barbs
     if density not in (1, 2, 3):
         raise ValueError(f"Invalid density value {density}")
 
@@ -43,19 +64,12 @@ def visualize_vectors(
     assert meshes[0].shape == meshes[1].shape
     tile_height, tile_width = meshes[0].shape
 
-    x_indices, y_indices = get_meshgrid(density, tile_width, tile_height)
-
-    # Select the vector components in a subgrid
-    u = meshes[0].isel(x=x_indices, y=y_indices).astype(np.float32)
-    v = meshes[1].isel(x=x_indices, y=y_indices).astype(np.float32)
-    # use the entire mesh for magnitude not just the sparse u,v
     mag: xr.DataArray = np.sqrt(
         meshes[0] ** 2 + meshes[1] ** 2,
     )  # pyright: ignore[reportAssignmentType]
-    # Initialize a plot with appropriate axes
+
     fig, ax = setup_tile_plot(tile_width, tile_height)
 
-    # If colormap background is desired, draw it now
     if draw_backing and colormap is not None:
         ax.imshow(
             mag,
@@ -67,24 +81,40 @@ def visualize_vectors(
             interpolation="nearest",
         )
 
-    # Scale the length up based on density
-    u *= LENGTH_SCALE[density - 1]
-    v *= LENGTH_SCALE[density - 1]
-    if scaling == VectorStyleParams.GlyphScaling.CONSTANT:
-        # normalize the vectors so their size is CONSTANT
-        u /= mag.isel(x=x_indices, y=y_indices)
-        v /= mag.isel(x=x_indices, y=y_indices)
+    # Build arrays with vector glyph positions
+    if cell_center_indices is None:
+        x_indices, y_indices = get_meshgrid(density, tile_width, tile_height)
     else:
-        # scale up just a little
-        # TODO: this should depend on dataset and its max magnitude
+        x_indices, y_indices = cell_center_indices
+        valid = (
+            np.isfinite(meshes[0].values[y_indices, x_indices])
+            & np.isfinite(meshes[1].values[y_indices, x_indices])
+        )
+        x_indices, y_indices = x_indices[valid], y_indices[valid]
+
+    # Build arrays to render vector glyphs
+    u = meshes[0].values[y_indices, x_indices].astype(np.float32)
+    v = meshes[1].values[y_indices, x_indices].astype(np.float32)
+
+    # Vector scaling
+    if scaling == VectorStyleParams.GlyphScaling.CONSTANT:
+        m = mag.values[y_indices, x_indices]
+        nz = m != 0
+        u[nz] /= m[nz]
+        v[nz] /= m[nz]
+    else:
+        # Scale up just a little
+        # TODO: this would ideally be based on the dataset max magnitude
         u *= 3
         v *= 3
+    # Scale the length based on density
+    u *= LENGTH_SCALE[density - 1]
+    v *= LENGTH_SCALE[density - 1]
 
     render_args = (x_indices, y_indices, u, v)
     if arrow_mag_color:
-        render_args += (mag.isel(x=x_indices, y=y_indices),)
+        render_args += (mag.values[y_indices, x_indices],)
 
-    # Sum the R, G, B values and determine a contrasting edgeline
     edgecolor = "black" if sum(matplotlib.colors.to_rgb(color)) > 1.5 else "white"
     render_kwargs = {
         "color": color,

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -29,8 +29,18 @@ def get_cell_center_indices(
     bbox: tuple[float, float, float, float],
     width: int,
     height: int,
+    density: int,
 ) -> tuple[NDArray[np.intp], NDArray[np.intp]]:
-    """Return (x_indices, y_indices) pixel coordinates of data cell centers."""
+    """Return (x_indices, y_indices) pixel coordinates of data cell centers within the tile.
+
+    Uses broadcast_like to expand 1-D dimensional coords (regular grids) to the
+    data's dimension order before raveling, ensuring x/y positions correspond to
+    values element-wise. Both returned arrays are 1D and the same length.
+
+    Subsampling mirrors get_meshgrid: cell centers are binned into pixel-space
+    buckets of size `grid_step`; bucket centers are averaged so very dense
+    datasets do not draw too many arrows in a single tile.
+    """
     x_full = das[0].x.broadcast_like(das[0])
     y_full = das[0].y.broadcast_like(das[0])
     px = np.floor(
@@ -41,7 +51,19 @@ def get_cell_center_indices(
     ).astype(np.intp)
 
     in_tile = (px >= 0) & (px < width) & (py >= 0) & (py < height)
-    return px[in_tile], py[in_tile]
+    px, py = px[in_tile], py[in_tile]
+
+    # Subsample data points to prevent too many vector glyphs
+    grid_step = 64 // (2 ** (density - 1))
+    bucket_ids = (px // grid_step) * (height // grid_step + 1) + (py // grid_step)
+    # all the buckets with more than one cell center
+    _, inverse = np.unique(bucket_ids, return_inverse=True)
+    # calculate a mean point for multiple cell centers by averaging their coords
+    counts = np.bincount(inverse)
+    px_sub = (np.bincount(inverse, weights=px) / counts).round().astype(np.intp)
+    py_sub = (np.bincount(inverse, weights=py) / counts).round().astype(np.intp)
+
+    return px_sub, py_sub
 
 
 def visualize_vectors(


### PR DESCRIPTION
- add a new style(s) that draws arrows at data cell centers
- this requires conditional computation of data cell indices
- those indices get passed into the existing vector tile drawing function and are used as the indices to draw plot glyphs (arrows)
- refactor data types and indexing methods in vector_styles.py so we can easily draw arrows either in regular grid or per cells
- when the cell density on tile is too high, divide cell centers into buckets, for every bucket with more than one cell center use their mean
- also render the tile for this style with extra margin and then crop down, that way glyphs won't get clipped by tile edge
  - also make sure that subsampling is phase aligned between tiles

Already had co-pilot do one review pass on the draft PR before rebasing: https://github.com/axiom-data-science/xpublish-wms/pull/3

### Examples:
<img width="829" height="615" alt="image" src="https://github.com/user-attachments/assets/32dad68e-2c1f-42e7-88b4-666cf35a67cc" />
Notice subsampling above, where sometimes a column (or a row) of arrows is rendered for each pair of adjacent cells (this happens when subsampling step is close to the data cell step but not exact). Matching the subsampling step with data cell spacing would be very difficult to do in a generic way, so it is what it is at least for now.

\
<img width="825" height="612" alt="image" src="https://github.com/user-attachments/assets/dc2d382d-a14f-4f41-b1d7-80a8c8f730f2" />
See that each data cell has only one arrow rendered at the center at high zoom (this was the core request/motivation for this style)