### PR TITLE
Add stroke parameter to GetMap query

### DIFF
--- a/xpublish_wms/query.py
+++ b/xpublish_wms/query.py
@@ -238,11 +238,17 @@ class WMSGetMapQuery(WMSBaseQuery):
         "black",
         description="Color of directional glyphs when using a vector style. This is a matplotlib color parameter.",
     )
-    density: int | None = Field(
-        None,
+    density: int = Field(
+        2,
         description="Density of directional glyphs when using a vector style.",
         ge=1,
         le=3,
+    )
+    stroke: int = Field(
+        3,
+        description="Outline thickness of drawn glyphs when using a vector style.",
+        ge=0,
+        le=10,
     )
 
     @field_validator("layers", mode="before")

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -318,7 +318,8 @@ class GetMap:
             self.styles = VectorStyleParams(
                 type="vector",
                 color=query.color,
-                density=query.density or 2,
+                density=query.density,
+                stroke=query.stroke,
                 scaling=VectorStyleParams.GlyphScaling.CONSTANT,
                 colorscale_range=query.colorscalerange,
                 colormap=None if palette_name == "none" else palette_name,

--- a/xpublish_wms/wms/get_map/style_types.py
+++ b/xpublish_wms/wms/get_map/style_types.py
@@ -25,6 +25,7 @@ class VectorStyleParams(BaseModel):
 
     type: Literal["vector"]
     color: str
+    stroke: int
     density: int
     scaling: GlyphScaling
     colorscale_range: tuple[float, float] | None

--- a/xpublish_wms/wms/get_map/vector_styles.py
+++ b/xpublish_wms/wms/get_map/vector_styles.py
@@ -22,7 +22,7 @@ LENGTH_SCALE = np.array([3, 2, 1]) * 9
 TAIL_WIDTH = np.array([3.5, 2, 1]) * 1.3
 HEAD_WIDTH = [2.5, 2.5, 3.5]
 # Arrow outline stroke width
-LINE_WIDTH = [5, 4, 1]
+LINE_WIDTH = np.array([5, 4, 1]) * 2
 
 
 def get_cell_center_indices(
@@ -66,6 +66,7 @@ def get_cell_center_indices(
 def visualize_vectors(
     meshes: Sequence[xr.DataArray],
     color: str,
+    stroke: int,
     density: int,
     scaling: VectorStyleParams.GlyphScaling,
     colorscale_range: tuple[float, float] | None = None,
@@ -134,16 +135,21 @@ def visualize_vectors(
     if arrow_mag_color:
         render_args += (mag.values[y_indices, x_indices],)
 
+    # If average of RGB is more than 0.5 use black stroke, white otherwise
     edgecolor = "black" if sum(matplotlib.colors.to_rgb(color)) > 1.5 else "white"
     render_kwargs = {
+        # solid fill color of glyph
         "color": color,
+        # glyph outline/stroke props
         "edgecolor": edgecolor,
-        "linewidth": LINE_WIDTH[density - 1],
+        "linewidth": LINE_WIDTH[density - 1] * stroke,
         "linestyle": "solid",
+        # glyph dimensions
         "width": TAIL_WIDTH[density - 1],
         "headwidth": HEAD_WIDTH[density - 1],
         "headlength": 3,
         "headaxislength": 2.8,
+        # glyph fill colormapping options
         "cmap": colormap if arrow_mag_color else None,
         "vmin": colorscale_range[0] if arrow_mag_color and colorscale_range else None,
         "vmax": colorscale_range[1] if arrow_mag_color and colorscale_range else None,


### PR DESCRIPTION
- add parameter to set arrow outline thickness
- provide better default thickness than the constant value before
- also add some comments and tiny refactor (provide density default value right in the pydantic model instead of doing it later)


<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/95de4306-113f-45ae-b0db-3607e0137f5e" />
