### PR TITLE
Rewrite ROMS grid to fix rendering

### DIFF
--- a/xpublish_wms/grids/roms.py
+++ b/xpublish_wms/grids/roms.py
@@ -14,6 +14,7 @@ from xpublish_wms.utils import (
     to_mercator,
 )
 
+
 class ROMSGrid(Grid):
     def __init__(self, ds: xr.Dataset):
         self.ds = ds
@@ -146,7 +147,10 @@ class ROMSGrid(Grid):
         # check all corners for the "special case" ROMS models that have invalid lat/lng for masked cells (see docstring)
         # this is the worst hack I have ever written in my career, please forgive me
         # TODO figure out if there's a better way to detect these models than checking the dataset name
-        if any(sub in self.ds.attrs.get("title", "").lower() for sub in ["cbofs", "dbofs", "nyofs"]):
+        if any(
+            sub in self.ds.attrs.get("title", "").lower()
+            for sub in ["cbofs", "dbofs", "nyofs"]
+        ):
             valid = (
                 np.isfinite(corner_ll)
                 & np.isfinite(corner_lr)
@@ -229,14 +233,12 @@ class ROMSGrid(Grid):
 
         inside = hits if known is None else hits & known
 
-
         if not inside.any():
             # A bbox smaller than a grid cell can sit entirely between the corners of a single cell.
             # I have a working approach for dealing with this edge case, but it adds a lot of complexity for a case we
             # are extremely unlikely to ever actually see
             # this also catches tiles that are completely outside the grid, which is a more common case
             raise Exception("No fully visible cells in bbox (skipping)")
-
 
         # Take a contiguous window around the visible cells rather than the
         # individual indices: dropping interior rows/columns would stitch cells

--- a/xpublish_wms/grids/roms.py
+++ b/xpublish_wms/grids/roms.py
@@ -14,7 +14,6 @@ from xpublish_wms.utils import (
     to_mercator,
 )
 
-
 class ROMSGrid(Grid):
     def __init__(self, ds: xr.Dataset):
         self.ds = ds
@@ -29,26 +28,36 @@ class ROMSGrid(Grid):
 
     @property
     def render_method(self) -> RenderMethod:
-        return RenderMethod.Quad
+        return RenderMethod.Triangle
 
     @property
     def crs(self) -> str:
         return "EPSG:4326"
 
+    def grid_mask(self, grid_point: str) -> Optional[xr.DataArray]:
+        """The land/sea mask for one of the staggered grids, eg 'rho' or 'u'."""
+
+        # use the wet/dry mask when available, otherwise use the standard mask.
+        mask = self.ds.get(f"wetdry_mask_{grid_point}")
+        if mask is None:
+            mask = self.ds.get(f"mask_{grid_point}")
+        if mask is None:
+            return None
+
+        if "time" in mask.cf.coords:
+            mask = mask.cf.isel(time=0).squeeze(drop=True).cf.drop_vars("time")
+        else:
+            mask = mask.cf.squeeze(drop=True)
+
+        return mask
+
     def mask(
         self,
         da: Union[xr.DataArray, xr.Dataset],
     ) -> Union[xr.DataArray, xr.Dataset]:
-        mask = self.ds[f'mask_{da.cf["latitude"].name.split("_")[1]}']
-        if "time" in mask.cf.coords:
-            mask = mask.cf.isel(time=0).squeeze(drop=True).cf.drop_vars("time")
-        else:
-            mask = mask.cf.squeeze(drop=True).copy(deep=True)
-
-        mask[:-1, :] = mask[:-1, :].where(mask[1:, :] == 1, 0)
-        mask[:, :-1] = mask[:, :-1].where(mask[:, 1:] == 1, 0)
-        mask[1:, :] = mask[1:, :].where(mask[:-1, :] == 1, 0)
-        mask[:, 1:] = mask[:, 1:].where(mask[:, :-1] == 1, 0)
+        mask = self.grid_mask(da.cf["latitude"].name.split("_")[-1])
+        if mask is None:
+            return da
 
         return da.where(mask == 1)
 
@@ -87,7 +96,90 @@ class ROMSGrid(Grid):
 
         return da, render_context
 
-    def filter_by_bbox(self, da, bbox, crs, render_context: Optional[dict] = dict()):
+    def tessellate(
+        self,
+        da: xr.DataArray,
+        render_context: Optional[dict] = {},
+    ) -> tuple[np.ndarray, dict]:
+        """
+        Builds the ROMS cells in a way that exactly matches the native grids for tested ROMS models (CBOFS, DBOFS, TBOFS, etc.)
+
+        There are two main ways to interpret the rho points of a ROMS grid as quads.
+        The old way in this plugin (using quadmesh) treated rho points as the cell centers,
+        and expanded the grid by one cell in each direction to get the corners of each cell.
+        However, the output grid does not match the real ROMS native grid when using this approach.
+
+        We now interpret rho points is as the corners of the cells, which exactly matches
+        the native ROMS grid. The complication is that the ROMS grid has masked cells,
+        and the approach for dealing with these masked cells varies from model to model.
+
+        On most models, the masked cells have valid lat/lng even in the mask, but the values
+        of masked cells are set to -9999. To render these models, we simply look at the
+        lower left corner `pts[i,j]` of each potential cell, and if that corner has valid data,
+        we render a cell `pts[i,j] / [i,j+1] / [i+1,j+1] / [i+1,j]` as two triangles and fill
+        the cell with the value of the lower-left corner `data[i,j]`.
+
+        However, certain ROMS models (CBOFS, DBOFS, NYOFS are known examples)
+        have masked cells that do not have valid lat/lng, and instead have wildly varying
+        lat/lng values. If we render these models using the same approach as above,
+        we will end up with many broken / smeared cells. For these models specifically,
+        we need to check if ALL FOUR corners of a potential cell have valid data, instead of
+        just the lower-left corner.
+
+        Even if there technically are better ways of rendering this grid, the above approach is
+        the only way to exactly match the native ROMS grid for all tested models. Another benefit
+        is that directly rendering the quads as triangles is considerably faster than using quadmesh,
+        which has to infer the corners of each cell.
+        """
+        x = np.asarray(da.x.values)
+        y = np.asarray(da.y.values)
+        z = np.asarray(da.values)
+
+        n_eta, n_xi = z.shape
+
+        # Get the corners of each cell
+        corner_ll = z[:-1, :-1]
+        corner_lr = z[:-1, 1:]
+        corner_ur = z[1:, 1:]
+        corner_ul = z[1:, :-1]
+
+        # See docstring above to understand why some models require an all-corners check
+        if render_context.get("quad_filter", "lower_left") == "all_corners":
+            valid = (
+                np.isfinite(corner_ll)
+                & np.isfinite(corner_lr)
+                & np.isfinite(corner_ur)
+                & np.isfinite(corner_ul)
+            )
+        else:
+            valid = np.isfinite(corner_ll)
+
+        eta, xi = np.nonzero(valid)
+
+        # Flattened (row-major) index of each rho corner into the vertex table
+        v_ll = eta * n_xi + xi
+        v_lr = eta * n_xi + (xi + 1)
+        v_ur = (eta + 1) * n_xi + (xi + 1)
+        v_ul = (eta + 1) * n_xi + xi
+
+        # Split each quad along one diagonal into two triangles
+        triangles = np.empty((2 * eta.size, 3), dtype=np.int64)
+        triangles[0::2] = np.stack([v_ll, v_lr, v_ur], axis=1)
+        triangles[1::2] = np.stack([v_ll, v_ur, v_ul], axis=1)
+
+        # Both triangles of a quad take the lower-left corner's value
+        # TODO do we want to instead take an average of the valid corner values?
+        # more accurate, but slower
+        cell_z = corner_ll[eta, xi]
+        tri_z = np.repeat(cell_z, 2)
+
+        render_context["tri_x"] = x.reshape(-1)
+        render_context["tri_y"] = y.reshape(-1)
+        render_context["tri_z"] = tri_z
+
+        return triangles, render_context
+
+    def filter_by_bbox(self, da, bbox, crs, render_context: Optional[dict] = {}):
         da = self.mask(da)
         render_context["masked"] = True
 
@@ -98,27 +190,71 @@ class ROMSGrid(Grid):
             )
             bbox = [bbox[0][0], bbox[1][0], bbox[0][1], bbox[1][1]]
 
-        adjust_lng = 0
-        if np.min(da.cf["longitude"]) < -180:
-            adjust_lng = 360
-        elif np.max(da.cf["longitude"]) > 180:
-            adjust_lng = -360
-
         # Get the x and y values
-        x = da.cf["longitude"] + adjust_lng
+        x = da.cf["longitude"]
         y = da.cf["latitude"]
 
-        # Find the indices of the data within the bounding box
-        x_inds = np.where((x >= bbox[0]) & (x <= bbox[2]))
-        y_inds = np.where((y >= bbox[1]) & (y <= bbox[3]))
+        if x.dims != y.dims or x.ndim != 2:
+            raise Exception("Mismatched dims for filter_by_bbox")
 
-        if len(x.dims) != len(y.dims) or len(x_inds) != len(y_inds):
-            raise Exception("Mismatched number of dims for filter_by_bbox")
+        # masked/land cells can carry filler positions (eg. in cbofs, dbofs), so they cannot be trusted to say
+        # where the grid is or whether they are in view
+        mask = self.grid_mask(x.name.split("_")[-1])
+        known = None
+        if mask is not None and mask.shape == x.shape:
+            known = np.asarray(mask.values) == 1
 
-        # Select and return the data within the bounding box
-        sel_dims = dict()
-        for i in range(len(x.dims)):
-            sel_dims[x.dims[i]] = np.intersect1d(x_inds[i], y_inds[i])
+        lng = np.asarray(x.values)
+        lat = np.asarray(y.values)
+
+        adjust_lng = 0
+        in_grid = lng if known is None else lng[known]
+        if in_grid.size:
+            if np.min(in_grid) < -180:
+                adjust_lng = 360
+            elif np.max(in_grid) > 180:
+                adjust_lng = -360
+
+        lng = lng + adjust_lng
+
+        # check which cells are in view using a joint lng/lat test to prevent mixing up rows and columns
+        hits = (
+            (lng >= bbox[0] - 0.0)
+            & (lng <= bbox[2] + 0.0)
+            & (lat >= bbox[1] - 0.0)
+            & (lat <= bbox[3] + 0.0)
+        )
+
+        inside = hits if known is None else hits & known
+
+
+        if not inside.any():
+            # A bbox smaller than a grid cell can sit entirely between the corners of a single cell.
+            # I have a working approach for dealing with this edge case, but it adds a lot of complexity for a case we
+            # are extremely unlikely to ever actually see
+            raise Exception("No fully visible cells in bbox (try using a larger one)")
+
+
+        # Take a contiguous window around the visible cells rather than the
+        # individual indices: dropping interior rows/columns would stitch cells
+        # together that are nowhere near each other on the grid
+        sel_dims = {}
+        for axis, dim in enumerate(x.dims):
+            hits = np.where(inside.any(axis=1 - axis))[0]
+            if hits.size == 0:
+                sel_dims = {dim: slice(0, 0) for dim in x.dims}
+                break
+
+            low = max(int(hits[0]) - 2, 0)
+            high = min(int(hits[-1]) + 3, inside.shape[axis])
+
+            # Keep at least one full cell in each direction, otherwise the data
+            # squeezes down to a line and can no longer be rendered as quads
+            if high - low < 2:
+                low = max(high - 2, 0)
+                high = min(low + 2, inside.shape[axis])
+
+            sel_dims[dim] = slice(low, high)
 
         da = da.isel(sel_dims)
         return da, render_context

--- a/xpublish_wms/grids/roms.py
+++ b/xpublish_wms/grids/roms.py
@@ -146,7 +146,7 @@ class ROMSGrid(Grid):
         # check all corners for the "special case" ROMS models that have invalid lat/lng for masked cells (see docstring)
         # this is the worst hack I have ever written in my career, please forgive me
         # TODO figure out if there's a better way to detect these models than checking the dataset name
-        if self.ds.attrs.get("title", "").lower() in ["cbofs", "dbofs", "nyofs"]:
+        if any(sub in self.ds.attrs.get("title", "").lower() for sub in ["cbofs", "dbofs", "nyofs"]):
             valid = (
                 np.isfinite(corner_ll)
                 & np.isfinite(corner_lr)
@@ -234,7 +234,8 @@ class ROMSGrid(Grid):
             # A bbox smaller than a grid cell can sit entirely between the corners of a single cell.
             # I have a working approach for dealing with this edge case, but it adds a lot of complexity for a case we
             # are extremely unlikely to ever actually see
-            raise Exception("No fully visible cells in bbox (try using a larger one)")
+            # this also catches tiles that are completely outside the grid, which is a more common case
+            raise Exception("No fully visible cells in bbox (skipping)")
 
 
         # Take a contiguous window around the visible cells rather than the

--- a/xpublish_wms/grids/roms.py
+++ b/xpublish_wms/grids/roms.py
@@ -143,8 +143,10 @@ class ROMSGrid(Grid):
         corner_ur = z[1:, 1:]
         corner_ul = z[1:, :-1]
 
-        # See docstring above to understand why some models require an all-corners check
-        if render_context.get("quad_filter", "lower_left") == "all_corners":
+        # check all corners for the "special case" ROMS models that have invalid lat/lng for masked cells (see docstring)
+        # this is the worst hack I have ever written in my career, please forgive me
+        # TODO figure out if there's a better way to detect these models than checking the dataset name
+        if self.ds.attrs.get("title", "").lower() in ["cbofs", "dbofs", "nyofs"]:
             valid = (
                 np.isfinite(corner_ll)
                 & np.isfinite(corner_lr)

--- a/xpublish_wms/wms/get_map/main.py
+++ b/xpublish_wms/wms/get_map/main.py
@@ -656,7 +656,12 @@ class GetMap:
                     {"x": render_context["tri_x"], "y": render_context["tri_y"]},
                 )
                 tris = pd.DataFrame(triangles.astype(int), columns=["v0", "v1", "v2"])
-                tris = tris.assign(z=da.values)
+
+                # A grid may supply an explicit per-triangle value (eg ROMS emits
+                # two triangles per grid cell, so there are more triangles than data
+                # points); otherwise there is one value per triangle in the data.
+                tri_z = render_context.get("tri_z")
+                tris = tris.assign(z=da.values if tri_z is None else tri_z)
             else:
                 # We are coloring the vertices by the data values
                 verts = pd.DataFrame({"x": da.x, "y": da.y, "z": da})


### PR DESCRIPTION
- Fixed mask step; the old way dropped about 20% of the actual data from the dataset overall. This was inadvertently hiding all of  the other issues present with this grid
- Uses the wet/dry mask for masking (when available) instead of the standard land/sea mask. This makes a huge difference for models with many wet/dry cells, like CIOFS
- The bbox selection before didn't actually work correctly; it left quite a bit of data that was only inside the lat range or only inside the lng range of the bbox

- (biggest change) rewrites the rendering method from using a `quadmesh` with each rho point as the cell center, to using rho points as the vertices, and dividing each cell into two triangles. A cell is rendered as long as the bottom-left vertexThe cell fill color is based on the value of the bottom left vertex in all cases. This exact method is the only way to make the rendered grid look exactly as it does in the model documentation (example [CBOFS](https://tidesandcurrents.noaa.gov/images/cbofs2_grid.png), [DBOFS](https://tidesandcurrents.noaa.gov/images/dbofs_grid.png), and [TBOFS](https://tidesandcurrents.noaa.gov/images/tbofs_grid.png) for spot-checking)

Here's where things get a bit complicated though: some models (CBOFS, DBOFS, NYOFS are known examples) have garbage lat/lng values at rho points that are on land, and they aren't removed during the masking step either. This makes our bottom-left check from above fail, and tiles with smeared cells are rendered: 
<img width="1564" height="1804" alt="image" src="https://github.com/user-attachments/assets/9f59efd2-3ca7-48d3-9a9d-b496ab7e839c" />

The solution for dealing with these models (that gives the same grid as the above reference images) is to only render the cells when all four vertices actually have valid data. This allows us to render the "good" cells while bypassing any cells that have potential bad vertex coordinates.

I don't actually agree with this being the best or most accurate way to represent ROMS (especially because the rho-points are technically at the centers of each grid cell in the true model; see https://www.myroms.org/wiki/Numerical_Solution_Technique), but since these outputs match the reference material exactly, it is technically the true "native grid" representation. Even though the old ROMS pipeline threw away a ton of data around the land/water boundaries, it did correctly render the grid cells as rho-center instead of rho-vertex. I am pretty sure that correctly dealing with the land/water boundary cells while also rendering rho-centered is going to be EXTREMELY hard though (plus it won't match the reference graphics anymore).



Might have to rewrite `sel_lat_lng` as well for GFI requests, since right now you sometimes have shaded cells that can't be queried through GFI (especially on the special-case models eg. CBOFS and DBOFS). The tradeoff is that we would give up interpolation in some cases, so the GFI values would actually be less accurate after the fix. Still have to think about the best way to solve this

PS: I am now aware that the HYCOM grid is just as broken as ROMS was before these changes, since it shares many of the same issues as were present here.